### PR TITLE
Fix bug that causes all X-ray bands to have the same value

### DIFF
--- a/SO_properties.py
+++ b/SO_properties.py
@@ -1292,6 +1292,7 @@ class SOProperties(HaloProperty):
                     if do_calculation[category]:
                         val = getattr(part_props, name)
                         if val is not None:
+                            assert SO[name].shape == val.shape, f"Attempting to store {name} with wrong dimensions"
                             if unit == "dimensionless":
                                 SO[name] = unyt.unyt_array(
                                     val.astype(dtype),

--- a/SO_properties.py
+++ b/SO_properties.py
@@ -695,7 +695,7 @@ class SOParticleData:
     def Xraylum(self):
         if self.Ngas == 0:
             return None
-        return self.gas_xraylum.sum()
+        return self.gas_xraylum.sum(axis=0)
 
     @lazy_property
     def gas_xrayphlum(self):
@@ -707,7 +707,7 @@ class SOParticleData:
     def Xrayphlum(self):
         if self.Ngas == 0:
             return None
-        return self.gas_xrayphlum.sum()
+        return self.gas_xrayphlum.sum(axis=0)
 
     @lazy_property
     def gas_compY(self):
@@ -746,13 +746,13 @@ class SOParticleData:
     def Xraylum_no_agn(self):
         if self.Ngas == 0:
             return None
-        return self.gas_xraylum[self.gas_no_agn].sum()
+        return self.gas_xraylum[self.gas_no_agn].sum(axis=0)
 
     @lazy_property
     def Xrayphlum_no_agn(self):
         if self.Ngas == 0:
             return None
-        return self.gas_xrayphlum[self.gas_no_agn].sum()
+        return self.gas_xrayphlum[self.gas_no_agn].sum(axis=0)
 
     @lazy_property
     def compY_no_agn(self):

--- a/aperture_properties.py
+++ b/aperture_properties.py
@@ -992,6 +992,7 @@ class ApertureProperties(HaloProperty):
             if do_calculation[category]:
                 val = getattr(part_props, name)
                 if val is not None:
+                    assert aperture_sphere[name].shape == val.shape, f"Attempting to store {name} with wrong dimensions"
                     if unit == "dimensionless":
                         aperture_sphere[name] = unyt.unyt_array(
                             val.astype(dtype),

--- a/projected_aperture_properties.py
+++ b/projected_aperture_properties.py
@@ -580,6 +580,7 @@ class ProjectedApertureProperties(HaloProperty):
                 if do_calculation[category]:
                     val = getattr(proj_part_props, name)
                     if val is not None:
+                        assert projected_aperture[name].shape == val.shape, f"Attempting to store {name} with wrong dimensions"
                         if unit == "dimensionless":
                             projected_aperture[name] = unyt.unyt_array(
                                 val.astype(dtype),

--- a/subhalo_properties.py
+++ b/subhalo_properties.py
@@ -938,9 +938,9 @@ class SubhaloProperties(HaloProperty):
                 val, dtype=dtype, units=unit, registry=registry
             )
             if do_calculation[category]:
-                val = getattr(part_props, name)
-                assert subhalo[name].shape == val.shape, f"Attempting to store {name} with wrong dimensions"
+                val = getattr(part_props, name)                
                 if val is not None:
+                    assert subhalo[name].shape == val.shape, f"Attempting to store {name} with wrong dimensions"
                     if unit == "dimensionless":
                         subhalo[name] = unyt.unyt_array(
                             val.astype(dtype),

--- a/subhalo_properties.py
+++ b/subhalo_properties.py
@@ -939,6 +939,7 @@ class SubhaloProperties(HaloProperty):
             )
             if do_calculation[category]:
                 val = getattr(part_props, name)
+                assert subhalo[name].shape == val.shape, f"Attempting to store {name} with wrong dimensions"
                 if val is not None:
                     if unit == "dimensionless":
                         subhalo[name] = unyt.unyt_array(


### PR DESCRIPTION
For each halo the code needs to sum the X-ray luminosities of the relevant particles. These luminosities are recorded in multiple bands so they're stored in a 2D array indexed as [particle_index, band_index]. The code was calling np.sum() on this array which returns a single, total luminosity. Numpy then broadcasts this scalar back to an array when we store the result.

This pull request adds some asserts to catch this type of bug in future and corrects the calculation to only sum over the particle axis of the 2D luminosity array.