### PR TITLE
Fix crash in SO properties unit test when running with unyt 2.9.5

### DIFF
--- a/dummy_halo_generator.py
+++ b/dummy_halo_generator.py
@@ -399,14 +399,18 @@ class DummyHaloGenerator:
                 registry=reg,
             )
             data["PartType0"]["Velocities"] = vs[gas_mask]
+            xrays = np.zeros((Ngas, 3))
+            xrays[:, 0] = 10.0 ** (7.0 * np.random.random(Ngas))
+            xrays[:, 1] = 10.0 ** (7.0 * np.random.random(Ngas))
+            xrays[:, 2] = 10.0 ** (7.0 * np.random.random(Ngas))
             data["PartType0"]["XrayLuminosities"] = unyt.unyt_array(
-                10.0 ** (7.0 * np.random.random(Ngas)),
+                xrays,
                 dtype=np.float64,
                 units="snap_length**2*snap_mass/snap_time**3",
                 registry=reg,
             )
             data["PartType0"]["XrayPhotonLuminosities"] = unyt.unyt_array(
-                10.0 ** (70.0 * np.random.random(Ngas)),
+                xrays,
                 dtype=np.float64,
                 units="1/snap_time",
                 registry=reg,

--- a/kinematic_properties.py
+++ b/kinematic_properties.py
@@ -131,23 +131,25 @@ def get_vmax(mass, radius):
 
 def get_axis_lengths(mass, position):
 
-    Itensor = (mass[:, None, None] / mass.sum()) * np.ones((mass.shape[0], 3, 3))
-    # Note: unyt currently ignores the position units in the *=
-    # i.e. Itensor is dimensionless throughout (even though it should not be)
+    Itensor = (mass[:, None, None] / mass.sum()) * np.ones((mass.shape[0], 3, 3))    
+    # Here we do the calculation without units and add them back in afterwards.
+    # This avoids problems due to differences in behaviour between unyt versions.
     for i in range(3):
         for j in range(3):
-            Itensor[:, i, j] *= position[:, i] * position[:, j]
+            Itensor[:, i, j] *= position[:, i].value * position[:, j].value
     Itensor = Itensor.sum(axis=0)
 
-    # linalg.eigenvals cannot deal with units anyway, so we have to add them
-    # back in
+    # linalg.eigenvals cannot deal with units anyway
     axes = np.linalg.eigvals(Itensor).real
     axes = np.clip(axes, 0.0, None)
-    axes = np.sqrt(axes) * position.units
+    axes = np.sqrt(axes)
 
     # sort the axes from long to short
     axes.sort()
     axes = axes[::-1]
+
+    # Assign units to the result
+    axes = axes * position.units
 
     return axes
 


### PR DESCRIPTION
The SO properties test crashes if we use unyt 2.9.5:
```
File "/cosma/home/jch/Codes/Flamingo/HaloProperties/SOAP/SO_properties.py", line 350, in TotalAxisLengths
    return get_axis_lengths(self.mass, self.position)
  File "/cosma/home/jch/Codes/Flamingo/HaloProperties/SOAP/kinematic_properties.py", line 139, in get_axis_lengths
    Itensor[:, i, j] *= position[:, i] * position[:, j]
```
Here, Itensor is dimensionless but position is a length. The result is a length so we can just do the calculation without units and add the units back on at the end.

I've also included a fix for the xray properties in the unit test here so that it's possible to run the test.