### PR TITLE
Register the field with mass-weighted iron from SNIa

### DIFF
--- a/aperture_properties.py
+++ b/aperture_properties.py
@@ -2405,6 +2405,20 @@ class ApertureParticleData:
         return (self.star_log10_Fe_from_SNIa_over_H_low_limit * self.mass_star).sum()
 
     @lazy_property
+    def LinearMassWeightedIronFromSNIaOverHydrogenOfStars(
+        self,
+    ) -> unyt.unyt_quantity:
+        """
+        Mass-weighted sum of the iron over hydrogen ratio for star particles,
+        times the solar ratio, set in the parameter file, and
+        only taking into account iron produced by SNIa.
+        """
+        if self.Nstar == 0:
+            return None
+        return (self.star_Fe_from_SNIa_over_H * self.mass_star).sum()
+
+
+    @lazy_property
     def HalfMassRadiusGas(self) -> unyt.unyt_quantity:
         """
         Half mass radius of gas.
@@ -2560,6 +2574,7 @@ class ApertureProperties(HaloProperty):
             "LogarithmicMassWeightedIronOverHydrogenOfStarsHighLimit",
             "GasMassInColdDenseDiffuseMetals",
             "LogarithmicMassWeightedIronFromSNIaOverHydrogenOfStarsLowLimit",
+            "LinearMassWeightedIronFromSNIaOverHydrogenOfStars",
         ]
     ]
 

--- a/property_table.py
+++ b/property_table.py
@@ -2082,6 +2082,21 @@ class PropertyTable:
                 "PartType4/IronMassFractionsFromSNIa",
             ],
         ),
+        "LinearMassWeightedIronFromSNIaOverHydrogenOfStars": (
+            "LinearMassWeightedIronFromSNIaOverHydrogenOfStars",
+            1,
+            np.float32,
+            "Msun",
+            "Sum of the iron over hydrogen ratio of stars, multiplied with the stellar mass, where only iron from SNIa is included.",
+            "star",
+            "FMantissa9",
+            False,
+            [
+                "PartType4/Masses",
+                "PartType4/ElementMassFractions",
+                "PartType4/IronMassFractionsFromSNIa",
+            ],
+        ),
     }
 
     # list of properties in the 'VR' category


### PR DESCRIPTION
This PR enables the Colibre branch of SOAP to produce a catalogue with halo properties that can be successfully used with the Colibre pipeline. Without this update, the pipeline would crash because of the missing field with mass-weighted iron from SNIa.