### PR TITLE
fixing None type bug

### DIFF
--- a/SO_properties.py
+++ b/SO_properties.py
@@ -808,8 +808,6 @@ class SOParticleData:
 
     @lazy_property
     def gas_densities(self):
-        if self.Ngas == 0:
-            return None
         return self.data["PartType0"]["Densities"][self.gas_selection]
 
     @lazy_property


### PR DESCRIPTION
This fixes a bug where gas_densities is set to None when a halo has no gas particles. When gas_densities is being indexed down the line, this gives an error as a Nonetype cannot be indexed.