### PR TITLE
Document group membership files

### DIFF
--- a/documentation/SOAP.tex
+++ b/documentation/SOAP.tex
@@ -247,4 +247,42 @@ profile before computing the density profile. This is the only place where neutr
 algorithm, except for the neutrino masses computed for the SOs. Neutrinos are not included in the calculation 
 of the centre of mass and centre of mass velocity.
 
+\section{Group membership files}
+
+Before SOAP can be run we generate a set of files which contain halo
+membership information for each particle in the SWIFT snapshot. The
+datasets in these files are stored in the same order and with the same
+partitioning between files as the datasets in the snapshots. This
+allows SOAP to read halo membership information for sub-regions of the
+simulation volume without reading the full VR output. These files may
+also be useful for visualising the input halo catalogue.
+
+The group membership files are HDF5 files with one group for each
+particle type, named PartType0, PartType1, ... as in the
+snapshots. Each group contains the following datasets:
+
+\begin{enumerate}
+\item \verb|GroupNr_all|: for each particle in the corresponding snapshot
+  file this contains the array index of the VR group which the
+  particle belongs to, regardless of whether it is bound or
+  unbound. Particles in no group have \verb|GroupNr_all|=-1.
+\item \verb|GroupNr_bound|: for each particle in the corresponding snapshot
+  file this contains the array index of the VR group which the
+  particle is bound to. If a particle is not bound to any group it
+  will have \verb|GroupNr_bound|=-1.
+\item \verb|Rank_bound|: the ranking by total energy of this particle within
+  the VR group it belongs to, or -1 if the particle is not bound to
+  any group. The particle with the most negative total energy has
+  \verb|Rank_bound|=0. Note that this is not the same as the potential
+  minimum.
+\end{enumerate}
+
+The GroupNr values stored here are zero based array indexes into the
+full VR halo catalogue, and not VELOCIraptor IDs (which start from
+one). The first group in the catalogue will have GroupNr=0 and ID=1.
+
+The snapshot and group membership files can be combined into a single
+virtual snapshot file which allows swiftsimio and gadgetviewer to read
+halo membership information alongside other particle properties.
+
 \end{document}

--- a/property_table.py
+++ b/property_table.py
@@ -20,6 +20,24 @@ def get_version_string():
     return f"{git_version} -- Compiled by user ``{username}'' on {hostname} on {timestamp}."
 
 
+def word_wrap_name(name):
+    """
+    Put a line break in if a name gets too long
+    """
+    maxlen=20
+    count=0
+    output=[]
+    last_was_lower=False
+    for i in range(len(name)):
+        next_char=name[i]
+        count += 1
+        if count > maxlen and next_char.isupper() and last_was_lower:
+            output.append("\-")
+        output.append(next_char)
+        last_was_lower=next_char.isupper()==False
+    return "".join(output)
+
+
 class PropertyTable:
     categories = ["basic", "general", "gas", "dm", "star", "baryon", "VR", "SOAP"]
     explanation = {
@@ -1507,7 +1525,7 @@ class PropertyTable:
 \\begin{document}"""
 
         tablestr = """\\begin{landscape}
-\\begin{longtable}{lllllllllll}
+\\begin{longtable}{p{20em}llllllllll}
 Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category & Compression\\\\
 \\multicolumn{11}{l}{\\rule{30pt}{0pt}Description}\\\\
 \\hline{}\\endhead{}"""
@@ -1516,6 +1534,7 @@ Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category & Compression\\\
             prop = self.properties[prop_name]
             footnotes = self.get_footnotes(prop_name)
             prop_outputname = f"{prop['name'].replace('_','')}{footnotes}"
+            prop_outputname = word_wrap_name(prop_outputname)
             prop_shape = f'{prop["shape"]}'
             prop_dtype = prop["dtype"]
             prop_units = f'${prop["units"]}$' if prop["units"] != "" else "(no unit)"


### PR DESCRIPTION
This adds a short section to the documentation that describes the group membership files.

I've also tried to stop the property table going off the page by allowing latex to line break long names if necessary.
