### PR TITLE
Add stellar com and vcom to aperture properties

### DIFF
--- a/aperture_properties.py
+++ b/aperture_properties.py
@@ -513,6 +513,12 @@ class ApertureParticleData:
         return get_inertia_tensor(self.mass_dm, self.pos_dm)
 
     @lazy_property
+    def com_star(self):
+        if self.Mstar == 0:
+            return None
+        return (self.star_mass_fraction[:, None] * self.pos_star).sum(axis=0) + self.centre
+
+    @lazy_property
     def vcom_star(self):
         if self.Mstar == 0:
             return None
@@ -858,7 +864,9 @@ class ApertureProperties(HaloProperty):
             "BHmaxAR",
             "BHmaxlasteventa",
             "com",
+            "com_star",
             "vcom",
+            "vcom_star",
             "Lgas",
             "Ldm",
             "Lstar",


### PR DESCRIPTION
I haven't added these properties to the projected apertures, but it's easy to do if that's wanted