### PR TITLE
Fix for unyt conversion error in inertia tensor calculation

### DIFF
--- a/kinematic_properties.py
+++ b/kinematic_properties.py
@@ -130,28 +130,13 @@ def get_vmax(mass, radius):
 
 
 def get_inertia_tensor(mass, position):
-    Itensor = (mass[:, None, None]) * np.ones((mass.shape[0], 3, 3))
-    # Note: unyt currently ignores the position units in the *=
-    # i.e. Itensor is dimensionless throughout (even though it should not be)
-    for i in range(3):
-        for j in range(3):
-            Itensor[:, i, j] *= position[:, i].value * position[:, j].value
-    Itensor = Itensor.sum(axis=0)
-    Itensor = (
-        np.array(
-            (
-                Itensor[0, 0],
-                Itensor[1, 1],
-                Itensor[2, 2],
-                Itensor[0, 1],
-                Itensor[0, 2],
-                Itensor[1, 2],
-            )
-        )
-        * position.units
-        * position.units
-        * mass.units
-    )
+
+    # 3x3 inertia tensor
+    Itensor = (mass[:, None, None] * position[:,None:, None] * position[:,None]).sum(axis=0)
+
+    # Symmetric, so only return lower triangle
+    Itensor = np.concatenate([np.diag(Itensor), Itensor[np.triu_indices(3,1)]])
+    
     return Itensor
 
 

--- a/kinematic_properties.py
+++ b/kinematic_properties.py
@@ -132,11 +132,13 @@ def get_vmax(mass, radius):
 def get_inertia_tensor(mass, position):
 
     # 3x3 inertia tensor
-    Itensor = (mass[:, None, None] * position[:,None:, None] * position[:,None]).sum(axis=0)
+    Itensor = (mass[:, None, None] * position[:, None:, None] * position[:, None]).sum(
+        axis=0
+    )
 
     # Symmetric, so only return lower triangle
-    Itensor = np.concatenate([np.diag(Itensor), Itensor[np.triu_indices(3,1)]])
-    
+    Itensor = np.concatenate([np.diag(Itensor), Itensor[np.triu_indices(3, 1)]])
+
     return Itensor
 
 

--- a/xray_calculator.py
+++ b/xray_calculator.py
@@ -228,15 +228,10 @@ class XrayCalculator:
         redshift = self.z_now
         scale_factor = 1 / (1 + redshift)
         data_n = np.log10(
-            element_mass_fractions[:, 0]
-            * densities.to(g * cm ** -3)
-            / mp
+            element_mass_fractions[:, 0] * densities.to(g * cm ** -3) / mp
         )
         data_T = np.log10(temperatures)
-        volumes = (
-            masses.astype(np.float64)
-            / densities.astype(np.float64)
-        ).to(cm ** 3)
+        volumes = (masses.astype(np.float64) / densities.astype(np.float64)).to(cm ** 3)
 
         # Create density mask, round to avoid numerical errors
         density_mask = (data_n >= np.round(self.density_bins.min(), 1)) & (


### PR DESCRIPTION
Fix relating to the problem caused by latest unyt package when calculating the inertia tensor of a collection of particles, as identified in #45. This is caused by a conversion exception in the latest version of unyt  (3.0.1).

Checking old and new versions produce the same result:
![image](https://github.com/SWIFTSIM/SOAP/assets/60343271/8e615ee9-8411-4e02-88a0-5f384f39dad8)

Faster than previous implementation:
![image](https://github.com/SWIFTSIM/SOAP/assets/60343271/7a0fa88d-3f2a-43ec-a4ba-6b2bf8c3c02e)

Implementation works regardless of whether unyts are attached or not:
![image](https://github.com/SWIFTSIM/SOAP/assets/60343271/25e2da37-7941-4517-9e4a-ef0fdbae973a)


 