### PR TITLE
Avoid gathering full halo catalogue on one MPI rank

### DIFF
--- a/chunk_tasks.py
+++ b/chunk_tasks.py
@@ -20,27 +20,6 @@ import result_set
 time_start = time.time()
 
 
-def send_array(comm, arr, dest, tag):
-    """Send an ndarray or unyt_array over MPI"""
-    unyt_array = isinstance(arr, unyt.unyt_array)
-    if unyt_array:
-        units = arr.units
-    else:
-        units = None
-    comm.send((unyt_array, arr.dtype, arr.shape, units), dest=dest, tag=tag)
-    comm.Send(arr, dest=dest, tag=tag)
-
-
-def recv_array(comm, src, tag):
-    """Receive an ndarray or unyt_array over MPI"""
-    unyt_array, dtype, shape, units = comm.recv(source=src, tag=tag)
-    arr = np.ndarray(shape, dtype=dtype)
-    if unyt_array:
-        arr = unyt.unyt_array(arr, units=units)
-    comm.Recv(arr, source=src, tag=tag)
-    return arr
-
-
 def share_array(comm, arr):
     """
     Take the array on rank 0 of communicator comm and copy it into
@@ -72,83 +51,27 @@ def box_wrap(pos, ref_pos, boxsize):
     return (pos - shift) % boxsize + shift
 
 
-class ChunkTaskList:
-    """
-    Stores a list of ChunkTasks to be executed.
-    """
-
-    def __init__(self, cellgrid, so_cat, halo_prop_list):
-
-        # Assign the input halos to chunk tasks
-        task_id = so_cat.halo_arrays["task_id"]
-
-        # Sort the halos by task ID
-        idx = np.argsort(task_id)
-        sorted_halo_arrays = {}
-        for name in so_cat.halo_arrays:
-            sorted_halo_arrays[name] = so_cat.halo_arrays[name][idx, ...]
-        task_id = task_id[idx]
-
-        # Find groups of halos with the same task ID
-        unique_ids, offsets, counts = np.unique(
-            task_id, return_index=True, return_counts=True
-        )
-        nr_chunks = len(counts)
-
-        # Create the task list
-        tasks = []
-        for chunk_nr, (offset, count) in enumerate(zip(offsets, counts)):
-
-            # Make the halo catalogue for this chunk
-            task_halo_arrays = {}
-            for name in sorted_halo_arrays:
-                task_halo_arrays[name] = sorted_halo_arrays[name][
-                    offset : offset + count, ...
-                ]
-
-            # Add an array to flag halos which have been processed
-            task_halo_arrays["done"] = unyt.unyt_array(
-                np.zeros(count, dtype=np.int8), dtype=np.int8
-            )
-
-            # Create the task for this chunk
-            tasks.append(
-                ChunkTask(task_halo_arrays, halo_prop_list, chunk_nr, nr_chunks)
-            )
-
-            # Report the size of the task
-            print(f"Chunk {chunk_nr} has {count} halos")
-
-        # Use number of halos as a rough estimate of cost.
-        # Do tasks with the most halos first so we're not waiting for a few big jobs at the end.
-        tasks.sort(key=lambda x: -x.halo_arrays["cofp"].shape[0])
-        self.tasks = tasks
-
-
 class ChunkTask:
     """
     Each ChunkTask is a set of halos in a patch of the simulation volume
     for which we want to evaluate spherical overdensity properties.
 
     Each ChunkTask is called collectively on all of the MPI ranks in one
-    compute node.
-
-    centres contains the halo centres
-    indexes contains the index of each halo in the input catalogue
-    radius  is the radius around each centre which we need to read in
+    compute node. The task imports the halos to be processed, reads in
+    the required patch of the snapshot and computes halo properties.    
     """
 
-    def __init__(self, halo_arrays=None, halo_prop_list=None, chunk_nr=0, nr_chunks=1):
+    def __init__(self, halo_prop_list=None, chunk_nr=0, nr_chunks=1):
 
-        self.halo_arrays = halo_arrays
         self.halo_prop_list = halo_prop_list
-        self.shared = False
         self.chunk_nr = chunk_nr
         self.nr_chunks = nr_chunks
-
+        self.shared = False
+        
     def __call__(
         self,
         cellgrid,
+        so_cat,
         comm,
         inter_node_rank,
         timings,
@@ -157,17 +80,9 @@ class ChunkTask:
         xray_calculator,
     ):
 
+        # Get communicator size and rank within this compute node
         comm_rank = comm.Get_rank()
         comm_size = comm.Get_size()
-
-        # Create object to store the results for this chunk
-        nr_halos = len(self.halo_arrays["index"].full)
-        results = result_set.ResultSet(initial_size=max(1, nr_halos // comm_size))
-
-        # Unpack arrays we need
-        centre = self.halo_arrays["cofp"]
-        read_radius = self.halo_arrays["read_radius"]
-        done = self.halo_arrays["done"]
 
         def message(m):
             if inter_node_rank >= 0:
@@ -181,6 +96,44 @@ class ChunkTask:
                         m,
                     )
                 )
+        
+        # The first rank on this node imports the halos to be processed
+        comm.barrier()
+        t0_halos = time.time()
+        if comm_rank == 0:
+            # Receive arrays
+            self.halo_arrays = so_cat.request_chunk(self.chunk_nr)
+            # Add a done flag for each halo
+            nr_halos = len(self.halo_arrays["index"])
+            self.halo_arrays["done"] = unyt.unyt_array(
+                np.zeros(nr_halos, dtype=np.int8), dtype=np.int8
+            )
+            # Will need to broadcast names of the halo properties
+            names = list(self.halo_arrays.keys())
+        else:
+            names = None
+            self.halo_arrays = {}
+        names = comm.bcast(names)
+        
+        # Then we copy the halo arrays into shared memory
+        for name in names:
+            if comm_rank == 0:
+                arr = self.halo_arrays[name]
+            else:
+                arr = None
+            self.halo_arrays[name] = share_array(comm, arr)
+        t1_halos = time.time()
+        nr_halos = len(self.halo_arrays["index"].full)
+        self.shared = True # So we know to explicitly free the shared memory regions
+        message("receiving %d halos for chunk %d took %.2fs" % (nr_halos, self.chunk_nr, t1_halos-t0_halos))
+        
+        # Create object to store the results for this chunk
+        results = result_set.ResultSet(initial_size=max(1, nr_halos // comm_size))
+
+        # Unpack arrays we need
+        centre = self.halo_arrays["cofp"]
+        read_radius = self.halo_arrays["read_radius"]
+        done = self.halo_arrays["done"]
 
         # Repeat until all halos have been done
         task_time_all_iterations = 0.0
@@ -376,89 +329,3 @@ class ChunkTask:
         # Return the names, dimensions and units of the quantities we computed
         # so that we can check they're consistent between chunks
         return results.get_metadata(comm)
-
-    @classmethod
-    def bcast(cls, comm, instance):
-        """
-        Broadcast a class instance over communicator comm.
-        instance is only significant on rank 0. Other ranks
-        don't have an instance yet, so this is a class method.
-
-        Halo arrays are put in shared memory instead of copying
-        to every rank.
-        """
-
-        comm_rank = comm.Get_rank()
-
-        # Create a class instance on ranks which don't have one
-        if comm_rank == 0:
-            self = instance
-        else:
-            self = cls()
-
-        # Broadcast the halo array names
-        if comm_rank == 0:
-            names = list(self.halo_arrays.keys())
-        else:
-            names = None
-        names = comm.bcast(names)
-
-        # Copy the arrays to shared memory
-        halo_arrays = {}
-        for name in names:
-            if comm_rank == 0:
-                arr = self.halo_arrays[name]
-            else:
-                arr = None
-            halo_arrays[name] = share_array(comm, arr)
-        self.halo_arrays = halo_arrays
-
-        # Broadcast quantities to calculate
-        self.halo_prop_list = comm.bcast(self.halo_prop_list)
-        self.shared = True
-
-        self.chunk_nr = comm.bcast(self.chunk_nr)
-        self.nr_chunks = comm.bcast(self.nr_chunks)
-
-        return self
-
-    def send(self, comm, dest, tag):
-
-        # Send quantities to compute
-        comm.send(self.halo_prop_list, dest, tag)
-
-        # Send halo array names
-        names = list(self.halo_arrays.keys())
-        comm.send(names, dest, tag)
-
-        # Send halo arrays
-        for name in names:
-            send_array(comm, self.halo_arrays[name], dest, tag)
-
-        comm.send(self.chunk_nr, dest, tag)
-        comm.send(self.nr_chunks, dest, tag)
-
-    @classmethod
-    def recv(cls, comm, src, tag):
-
-        # Receive quantities to compute
-        halo_prop_list = comm.recv(source=src, tag=tag)
-
-        # We might receive None instead of a task if there are no more tasks.
-        # Just return None in that case.
-        if halo_prop_list is None:
-            return None
-
-        # Receive halo array names
-        names = comm.recv(source=src, tag=tag)
-
-        # Receive halo arrays
-        halo_arrays = {}
-        for name in names:
-            halo_arrays[name] = recv_array(comm, src, tag)
-
-        chunk_nr = comm.recv(source=src, tag=tag)
-        nr_chunks = comm.recv(source=src, tag=tag)
-
-        # Construct the class instance
-        return cls(halo_arrays, halo_prop_list, chunk_nr, nr_chunks)

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -416,7 +416,8 @@ def compute_halo_properties():
         args.chunks,
         args.halo_sizes_file.format(snap_nr=args.snapshot_nr),
     )
-
+    so_cat.start_request_thread()
+    
     # Generate the chunk task list
     if comm_world_rank == 0:
         task_list = chunk_tasks.ChunkTaskList(
@@ -481,6 +482,9 @@ def compute_halo_properties():
         task_type=chunk_tasks.ChunkTask,
     )
 
+    # Can stop the halo request thread now that all chunk tasks have executed
+    so_cat.stop_request_thread()
+    
     # Check metadata for consistency between chunks. Sets ref_metadata on all ranks,
     # including those that processed no halos.
     ref_metadata = result_set.check_metadata(metadata, comm_inter_node, comm_world)

--- a/domain_decomposition.py
+++ b/domain_decomposition.py
@@ -7,7 +7,7 @@ import unyt
 from mpi4py import MPI
 
 
-def peano_decomposition(boxsize, centres, nr_chunks, comm):
+def peano_decomposition(boxsize, local_halo, nr_chunks, comm):
     """
     Gadget style domain decomposition using Peano-Hilbert curve.
     Allows an arbitrary number of chunks and tries to put equal
@@ -16,7 +16,9 @@ def peano_decomposition(boxsize, centres, nr_chunks, comm):
     The array of halo centres is assumed to be distributed over
     communicator comm.
 
-    Returns chunk index for each input halo centre.
+    Sorts halos by chunk index and returns the number of halos
+    in each chunk. local_halo is a dict of distributed unyt
+    arrays with the halo properties.
     
     Will not work well for zoom simulations. Could use a grid
     which just covers the zoom region?
@@ -25,6 +27,7 @@ def peano_decomposition(boxsize, centres, nr_chunks, comm):
     comm_rank = comm.Get_rank()
 
     # Find size of grid to use to calculate PH keys
+    centres = local_halo["cofp"]
     bits_per_dimension = 10
     cells_per_dimension = 2 ** bits_per_dimension
     grid_size = boxsize / cells_per_dimension
@@ -47,25 +50,14 @@ def peano_decomposition(boxsize, centres, nr_chunks, comm):
     order = psort.parallel_sort(phkey, return_index=True, comm=comm)
     del phkey
 
-    # Find number of halos on previous ranks
-    nr_halos_previous = comm.scan(nr_halos) - nr_halos
+    # Reorder the halos
+    for name in local_halo:
+        local_halo[name] = psort.fetch_elements(local_halo[name], order, comm=comm)
 
-    # Find global indexes of halos on this rank
-    index = np.arange(nr_halos, dtype=int) + nr_halos_previous
-
-    # Reorder indexes so that they're sorted by PH key
-    index = psort.fetch_elements(index, order, comm=comm)
-
-    # Assign contiguous ranges of PH sorted halos to chunks
-    halos_per_chunk = max(1, total_nr_halos // nr_chunks)
-    sorted_index = np.arange(nr_halos, dtype=int) + nr_halos_previous
-    task_id = (sorted_index // halos_per_chunk).clip(min=0, max=nr_chunks - 1)
-
-    # Sort task_ids back into original order
-    order = psort.parallel_sort(index, return_index=True, comm=comm)
-    task_id = psort.fetch_elements(task_id, order, comm=comm)
-
-    assert np.all(task_id >= 0)
-    assert np.all(task_id < nr_chunks)
-
-    return task_id
+    # Decide how many halos to put in each chunk
+    chunk_size = np.zeros(nr_chunks, dtype=int)
+    chunk_size[:] = total_nr_halos // nr_chunks
+    chunk_size[:total_nr_halos % nr_chunks] += 1
+    assert np.sum(chunk_size) == total_nr_halos
+    
+    return chunk_size

--- a/mpi_tags.py
+++ b/mpi_tags.py
@@ -1,0 +1,6 @@
+#!/bin/env python
+
+REQUEST_TASK_TAG  = 1
+ASSIGN_TASK_TAG   = 2
+HALO_REQUEST_TAG = 3
+HALO_RESPONSE_TAG = 4

--- a/sleepy_recv.py
+++ b/sleepy_recv.py
@@ -1,0 +1,21 @@
+#!/bin/env python
+
+import time
+
+def sleepy_recv(comm, tag, status=None):
+    """
+    Wait for a message without keeping a core spinning so that we leave
+    the core available to run jobs and release the GIL. Checks for
+    incoming messages at exponentially increasing intervals starting
+    at min_delay up to a limit of max_delay. Sleeps between checks.
+    """
+    min_delay = 1.0e-5
+    max_delay = 5.0
+    request = comm.irecv(tag=tag)
+    delay = min_delay
+    while True:
+        completed, message = request.test(status=status)
+        if completed:
+            return message
+        delay = min(max_delay, delay * 2)
+        time.sleep(delay)

--- a/task_queue.py
+++ b/task_queue.py
@@ -2,33 +2,13 @@
 
 import time
 import threading
-import time
 from mpi4py import MPI
 import collections
 import numpy as np
 import shared_array
 
-REQUEST_TASK_TAG = 1
-ASSIGN_TASK_TAG = 2
-
-
-def sleepy_recv(comm, tag):
-    """
-    Wait for a message without keeping a core spinning so that we leave
-    the core available to run jobs and release the GIL. Checks for
-    incoming messages at exponentially increasing intervals starting
-    at min_delay up to a limit of max_delay. Sleeps between checks.
-    """
-    min_delay = 1.0e-5
-    max_delay = 5.0
-    request = comm.irecv(tag=tag)
-    delay = min_delay
-    while True:
-        completed, message = request.test()
-        if completed:
-            return message
-        delay = min(max_delay, delay * 2)
-        time.sleep(delay)
+from mpi_tags import REQUEST_TASK_TAG, ASSIGN_TASK_TAG
+from sleepy_recv import sleepy_recv
 
 
 def distribute_tasks(tasks, comm, task_type):

--- a/task_queue.py
+++ b/task_queue.py
@@ -11,7 +11,7 @@ from mpi_tags import REQUEST_TASK_TAG, ASSIGN_TASK_TAG
 from sleepy_recv import sleepy_recv
 
 
-def distribute_tasks(tasks, comm, task_type):
+def distribute_tasks(tasks, comm):
     """
     Listen for and respond to requests for tasks to do
     """
@@ -22,12 +22,7 @@ def distribute_tasks(tasks, comm, task_type):
     while nr_done < comm_size:
         request_src = sleepy_recv(comm, REQUEST_TASK_TAG)
         if next_task < nr_tasks:
-            if task_type is None:
-                # Use generic mpi4py send
-                comm.send(tasks[next_task], request_src, tag=ASSIGN_TASK_TAG)
-            else:
-                # Task provides its own send method
-                tasks[next_task].send(comm, request_src, tag=ASSIGN_TASK_TAG)
+            comm.send(tasks[next_task], request_src, tag=ASSIGN_TASK_TAG)
             next_task += 1
         else:
             comm.send(None, request_src, tag=ASSIGN_TASK_TAG)
@@ -74,7 +69,6 @@ def execute_tasks(
     comm_workers,
     queue_per_rank=False,
     return_timing=False,
-    task_type=None,
 ):
     """
     Execute the tasks in tasks, which should be a sequence of
@@ -128,15 +122,13 @@ def execute_tasks(
     # First rank in comm_master starts a thread to hand out tasks
     if master_rank == 0:
         if queue_per_rank:
-            if task_type is not None:
-                raise NotImplementedError("Can't specify task type with queue per rank")
             task_queue_thread = threading.Thread(
                 target=distribute_tasks_with_queue_per_rank,
                 args=(tasks, comm_master_local),
             )
         else:
             task_queue_thread = threading.Thread(
-                target=distribute_tasks, args=(tasks, comm_master_local, task_type)
+                target=distribute_tasks, args=(tasks, comm_master_local)
             )
         task_queue_thread.start()
 
@@ -153,12 +145,7 @@ def execute_tasks(
         # which doesn't need to be duplicated to all ranks.
         if worker_rank == 0:
             comm_master_local.send(master_rank, 0, tag=REQUEST_TASK_TAG)
-            if task_type is None:
-                # generic recv
-                task = comm_master_local.recv(tag=ASSIGN_TASK_TAG)
-            else:
-                # task provides its own recv
-                task = task_type.recv(comm_master_local, 0, ASSIGN_TASK_TAG)
+            task = comm_master_local.recv(tag=ASSIGN_TASK_TAG)
         else:
             task = None
 


### PR DESCRIPTION
Attempts to address #46.

This modifies SOAP so that it no longer collects the full halo catalogue on MPI rank zero. Previously we would gather all of the halos on rank zero, split the volume into chunks, and generate a ChunkTask instance for each chunk which contained the halos in that chunk. Rank zero would then send these chunk tasks to compute nodes to be executed. This adds a lot of extra memory usage on the first node if the halo catalogue is large.

In this branch the ChunkTasks no longer contain halo information. Instead, when a chunk task executes its first job is to request the halo information it needs from the distributed halo catalogue. Each MPI rank runs an extra thread which responds to requests for halos. This thread sleeps most of the time and wakes at intervals to check for requests.

Since the ChunkTask instances are now small I've removed the functions for sending, receiving and broadcasting them efficiently. We can just use mpi4py's default method of sending python objects by pickling them.