### PR TITLE
Change data type of centre of mass quantities to float64

### DIFF
--- a/property_table.py
+++ b/property_table.py
@@ -1163,7 +1163,7 @@ class PropertyTable:
         "com": (
             "CentreOfMass",
             3,
-            np.float32,
+            np.float64,
             "Mpc",
             "Centre of mass.",
             "basic",
@@ -1173,7 +1173,7 @@ class PropertyTable:
         "com_gas": (
             "GasCentreOfMass",
             3,
-            np.float32,
+            np.float64,
             "Mpc",
             "Centre of mass of gas.",
             "gas",
@@ -1183,7 +1183,7 @@ class PropertyTable:
         "com_star": (
             "StellarCentreOfMass",
             3,
-            np.float32,
+            np.float64,
             "Mpc",
             "Centre of mass of stars.",
             "star",


### PR DESCRIPTION
Several centre of mass quantities in property_table.py have data type float32 and compression method "DScale5". This doesn't make sense because a float32 doesn't have enough precision to store 5 decimal places for typical halo positions in FLAMINGO. The compression script also converts any DScale5 quantities to float64, which masks the loss of precision.

This just changes the affected quantities to float64 in property_table.py.
