### PR TITLE
Remove deprecated unyt functions

### DIFF
--- a/SO_properties.py
+++ b/SO_properties.py
@@ -202,12 +202,12 @@ class SOParticleData:
             typearr[:] = ptype
             types.append(typearr)
             groupnr.append(self.data[ptype]["GroupNr_bound"])
-        self.mass = unyt.array.uconcatenate(mass)
-        self.radius = unyt.array.uconcatenate(radius)
-        self.position = unyt.array.uconcatenate(position)
-        self.velocity = unyt.array.uconcatenate(velocity)
+        self.mass = np.concatenate(mass)
+        self.radius = np.concatenate(radius)
+        self.position = np.concatenate(position)
+        self.velocity = np.concatenate(velocity)
         self.types = np.concatenate(types)
-        self.groupnr = unyt.array.uconcatenate(groupnr)
+        self.groupnr = np.concatenate(groupnr)
 
         # figure out which particles in the list are bound to a halo that is not the
         # central halo
@@ -221,8 +221,8 @@ class SOParticleData:
             )
             pos = self.data["PartType6"]["Coordinates"] - self.centre[None, :]
             nur = np.sqrt(np.sum(pos ** 2, axis=1))
-            all_mass = unyt.array.uconcatenate([self.mass, numass])
-            all_r = unyt.array.uconcatenate([self.radius, nur])
+            all_mass = np.concatenate([self.mass, numass/unyt.dimensionless])
+            all_r = np.concatenate([self.radius, nur])
         else:
             all_mass = self.mass
             all_r = self.radius
@@ -332,8 +332,8 @@ class SOParticleData:
         _, vmax = get_vmax(self.mass, self.radius)
         if vmax > 0:
             vrel = self.velocity - self.vcom[None, :]
-            Ltot = unyt.array.unorm(
-                (self.mass[:, None] * unyt.array.ucross(self.position, vrel)).sum(
+            Ltot = np.linalg.norm(
+                (self.mass[:, None] * np.cross(self.position, vrel)).sum(
                     axis=0
                 )
             )
@@ -569,7 +569,7 @@ class SOParticleData:
         baryon_relvel = self.baryon_vel - self.baryon_vcom[None, :]
         return (
             self.baryon_masses[:, None]
-            * unyt.array.ucross(self.baryon_pos, baryon_relvel)
+            * np.cross(self.baryon_pos, baryon_relvel)
         ).sum(axis=0)
 
     @lazy_property
@@ -1364,6 +1364,8 @@ class SOProperties(HaloProperty):
             "Velocities",
             "XrayLuminosities",
             "XrayPhotonLuminosities",
+            "XrayLuminositiesRestframe",
+            "XrayPhotonLuminositiesRestframe",
         ],
         "PartType1": ["Coordinates", "GroupNr_bound", "Masses", "Velocities"],
         "PartType4": [

--- a/SO_properties.py
+++ b/SO_properties.py
@@ -221,7 +221,7 @@ class SOParticleData:
             )
             pos = self.data["PartType6"]["Coordinates"] - self.centre[None, :]
             nur = np.sqrt(np.sum(pos ** 2, axis=1))
-            all_mass = np.concatenate([self.mass, numass/unyt.dimensionless])
+            all_mass = np.concatenate([self.mass, numass / unyt.dimensionless])
             all_r = np.concatenate([self.radius, nur])
         else:
             all_mass = self.mass
@@ -333,9 +333,7 @@ class SOParticleData:
         if vmax > 0:
             vrel = self.velocity - self.vcom[None, :]
             Ltot = np.linalg.norm(
-                (self.mass[:, None] * np.cross(self.position, vrel)).sum(
-                    axis=0
-                )
+                (self.mass[:, None] * np.cross(self.position, vrel)).sum(axis=0)
             )
             return Ltot / (np.sqrt(2.0) * self.Mtotpart * self.SO_r * vmax)
         return None
@@ -568,8 +566,7 @@ class SOParticleData:
             return None
         baryon_relvel = self.baryon_vel - self.baryon_vcom[None, :]
         return (
-            self.baryon_masses[:, None]
-            * np.cross(self.baryon_pos, baryon_relvel)
+            self.baryon_masses[:, None] * np.cross(self.baryon_pos, baryon_relvel)
         ).sum(axis=0)
 
     @lazy_property

--- a/aperture_properties.py
+++ b/aperture_properties.py
@@ -70,10 +70,10 @@ class ApertureParticleData:
             typearr[:] = ptype
             types.append(typearr)
 
-        self.mass = unyt.array.uconcatenate(mass)
-        self.position = unyt.array.uconcatenate(position)
-        self.radius = unyt.array.uconcatenate(radius)
-        self.velocity = unyt.array.uconcatenate(velocity)
+        self.mass = np.concatenate(mass)
+        self.position = np.concatenate(position)
+        self.radius = np.concatenate(radius)
+        self.velocity = np.concatenate(velocity)
         self.types = np.concatenate(types)
 
         self.mask = self.radius <= self.aperture_radius
@@ -414,8 +414,8 @@ class ApertureParticleData:
         if vmax == 0:
             return None
         vrel = self.velocity - self.vcom[None, :]
-        Ltot = unyt.array.unorm(
-            (self.mass[:, None] * unyt.array.ucross(self.position, vrel)).sum(axis=0)
+        Ltot = np.linalg.norm(
+            (self.mass[:, None] * np.cross(self.position, vrel)).sum(axis=0)
         )
         return Ltot / (np.sqrt(2.0) * self.Mtot * self.aperture_radius * vmax)
 

--- a/check_subhalo_ranking.py
+++ b/check_subhalo_ranking.py
@@ -6,18 +6,16 @@ import h5py
 import virgo.util.match as m
 
 # Read VR IDs and positions
-# filename="/cosma8/data/dp004/flamingo/Runs/L1000N1800/HYDRO_FIDUCIAL/VR/catalogue_0077/vr_catalogue_0077.properties.0"
-filename = "/cosma8/data/dp004/flamingo/Runs/L0100N0180/HYDRO_FIDUCIAL/VR/halos_0006.properties.0"
+filename="/cosma8/data/dp004/flamingo/Runs/L1000N0900/HYDRO_FIDUCIAL_DATA/HYDRO_FIDUCIAL/VR/catalogue_0077/vr_catalogue_0077.properties.0"
 with h5py.File(filename, "r") as infile:
     vr_id = infile["ID"][...]
     vr_host_id = infile["hostHaloID"][...]
 
 # Read SOAP output
-# filename="/snap8/scratch/dp004/jch/FLAMINGO/ScienceRuns/L1000N1800/HYDRO_FIDUCIAL/halo_properties/halo_properties_0077.hdf5"
-filename = "/snap8/scratch/dp004/jch/FLAMINGO/ScienceRuns/L0100N0180/HYDRO_FIDUCIAL/halo_properties/halo_properties_0006.hdf5"
+filename="/cosma8/data/dp004/flamingo/Runs/L1000N0900/HYDRO_FIDUCIAL_DATA/HYDRO_FIDUCIAL/SOAP/halo_properties_0077.hdf5"
 with h5py.File(filename, "r") as infile:
     soap_id = infile["VR/ID"][...]
-    soap_rank = infile["VR/SubhaloRankByBoundMass"][...]
+    soap_rank = infile["SOAP/SubhaloRankByBoundMass"][...]
     soap_host_id = infile["VR/HostHaloID"][...]
     soap_mass = infile["BoundSubhaloProperties/TotalMass"][...]
 

--- a/check_subhalo_ranking.py
+++ b/check_subhalo_ranking.py
@@ -6,13 +6,13 @@ import h5py
 import virgo.util.match as m
 
 # Read VR IDs and positions
-filename="/cosma8/data/dp004/flamingo/Runs/L1000N0900/HYDRO_FIDUCIAL_DATA/HYDRO_FIDUCIAL/VR/catalogue_0077/vr_catalogue_0077.properties.0"
+filename = "/cosma8/data/dp004/flamingo/Runs/L1000N0900/HYDRO_FIDUCIAL_DATA/HYDRO_FIDUCIAL/VR/catalogue_0077/vr_catalogue_0077.properties.0"
 with h5py.File(filename, "r") as infile:
     vr_id = infile["ID"][...]
     vr_host_id = infile["hostHaloID"][...]
 
 # Read SOAP output
-filename="/cosma8/data/dp004/flamingo/Runs/L1000N0900/HYDRO_FIDUCIAL_DATA/HYDRO_FIDUCIAL/SOAP/halo_properties_0077.hdf5"
+filename = "/cosma8/data/dp004/flamingo/Runs/L1000N0900/HYDRO_FIDUCIAL_DATA/HYDRO_FIDUCIAL/SOAP/halo_properties_0077.hdf5"
 with h5py.File(filename, "r") as infile:
     soap_id = infile["VR/ID"][...]
     soap_rank = infile["SOAP/SubhaloRankByBoundMass"][...]

--- a/kinematic_properties.py
+++ b/kinematic_properties.py
@@ -44,7 +44,7 @@ def get_angular_momentum(
         vrel = velocity
     else:
         vrel = velocity - ref_velocity[None, :]
-    return (mass[:, None] * unyt.array.ucross(prel, vrel)).sum(axis=0)
+    return (mass[:, None] * np.cross(prel, vrel)).sum(axis=0)
 
 
 def get_angular_momentum_and_kappa_corot(
@@ -79,9 +79,9 @@ def get_angular_momentum_and_kappa_corot(
     else:
         vrel = velocity - ref_velocity[None, :]
 
-    Lpart = mass[:, None] * unyt.array.ucross(prel, vrel)
+    Lpart = mass[:, None] * np.cross(prel, vrel)
     Ltot = Lpart.sum(axis=0)
-    Lnrm = unyt.array.unorm(Ltot)
+    Lnrm = np.linalg.norm(Ltot)
 
     if do_counterrot_mass:
         M_counterrot = unyt.unyt_array(
@@ -130,6 +130,7 @@ def get_vmax(mass, radius):
 
 
 def get_inertia_tensor(mass, position):
+
 
     # 3x3 inertia tensor
     Itensor = (mass[:, None, None] * position[:, None:, None] * position[:, None]).sum(

--- a/kinematic_properties.py
+++ b/kinematic_properties.py
@@ -131,7 +131,6 @@ def get_vmax(mass, radius):
 
 def get_inertia_tensor(mass, position):
 
-
     # 3x3 inertia tensor
     Itensor = (mass[:, None, None] * position[:, None:, None] * position[:, None]).sum(
         axis=0

--- a/projected_aperture_properties.py
+++ b/projected_aperture_properties.py
@@ -48,12 +48,12 @@ class ProjectedApertureParticleData:
             typearr[:] = ptype
             types.append(typearr)
 
-        self.mass = unyt.array.uconcatenate(mass)
-        self.position = unyt.array.uconcatenate(position)
-        self.radius_projx = unyt.array.uconcatenate(radius_projx)
-        self.radius_projy = unyt.array.uconcatenate(radius_projy)
-        self.radius_projz = unyt.array.uconcatenate(radius_projz)
-        self.velocity = unyt.array.uconcatenate(velocity)
+        self.mass = np.concatenate(mass)
+        self.position = np.concatenate(position)
+        self.radius_projx = np.concatenate(radius_projx)
+        self.radius_projy = np.concatenate(radius_projy)
+        self.radius_projz = np.concatenate(radius_projz)
+        self.velocity = np.concatenate(velocity)
         self.types = np.concatenate(types)
 
         self.mask_projx = self.radius_projx <= self.aperture_radius

--- a/property_table.py
+++ b/property_table.py
@@ -32,7 +32,7 @@ def word_wrap_name(name):
         next_char = name[i]
         count += 1
         if count > maxlen and next_char.isupper() and last_was_lower:
-            output.append("\-")
+            output.append(r"\-")
         output.append(next_char)
         last_was_lower = next_char.isupper() == False
     return "".join(output)
@@ -1530,7 +1530,7 @@ class PropertyTable:
 \\begin{document}"""
 
         tablestr = """\\begin{landscape}
-\\begin{longtable}{p{20em}llllllllll}
+\\begin{longtable}{p{15em}llllllllll}
 Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category & Compression\\\\
 \\multicolumn{11}{l}{\\rule{30pt}{0pt}Description}\\\\
 \\hline{}\\endhead{}"""
@@ -1587,7 +1587,7 @@ Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category & Compression\\\
                 tablestr += "\\hline{}"
             tablestr += "\\rule{0pt}{4ex}"
             tablestr += " & ".join([v for v in print_table_props]) + "\\\\*\n"
-            tablestr += f"\\multicolumn{{10}}{{p{{20cm}}}}{{\\rule{{30pt}}{{0pt}}{prop_description}}}\\\\\n"
+            tablestr += f"\\multicolumn{{10}}{{p{{15cm}}}}{{\\rule{{30pt}}{{0pt}}{prop_description}}}\\\\\n"
         tablestr += """\\end{longtable}
 \\end{landscape}"""
         tailstr = "\\end{document}"

--- a/result_set.py
+++ b/result_set.py
@@ -59,7 +59,7 @@ def concatenate(result_sets):
 
         # Store concatenated arrays in the output
         list_of_arrays = [rs.result_arrays[name][0] for rs in result_sets]
-        concatenated_array = unyt.array.uconcatenate(list_of_arrays, axis=0)
+        concatenated_array = np.concatenate(list_of_arrays, axis=0)
         description = rs.result_arrays[name][1]
         output.result_arrays[name] = [concatenated_array, description]
 

--- a/subhalo_properties.py
+++ b/subhalo_properties.py
@@ -62,10 +62,10 @@ class SubhaloParticleData:
             typearr[:] = ptype
             types.append(typearr)
 
-        self.mass = unyt.array.uconcatenate(mass)
-        self.position = unyt.array.uconcatenate(position)
-        self.radius = unyt.array.uconcatenate(radius)
-        self.velocity = unyt.array.uconcatenate(velocity)
+        self.mass = np.concatenate(mass)
+        self.position = np.concatenate(position)
+        self.radius = np.concatenate(radius)
+        self.velocity = np.concatenate(velocity)
         self.types = np.concatenate(types)
 
     @lazy_property
@@ -341,10 +341,10 @@ class SubhaloParticleData:
         if self.R_vmax > 0 and self.Vmax > 0:
             mask_r_vmax = self.radius <= self.R_vmax
             vrel = self.velocity[mask_r_vmax, :] - self.vcom[None, :]
-            Ltot = unyt.array.unorm(
+            Ltot = np.linalg.norm(
                 (
                     self.mass[mask_r_vmax, None]
-                    * unyt.array.ucross(self.position[mask_r_vmax, :], vrel)
+                    * np.cross(self.position[mask_r_vmax, :], vrel)
                 ).sum(axis=0)
             )
             M_r_vmax = self.mass[mask_r_vmax].sum()

--- a/test_SO_radius_calculation.py
+++ b/test_SO_radius_calculation.py
@@ -60,7 +60,7 @@ def test_SO_radius_calculation():
         ax[0][0].semilogy(ordered_radius, density, "o-")
         ax[1][0].semilogy(ordered_radius, cumulative_mass, "o-")
         if SO_r >= 0.0 * unyt.kpc:
-            rrange = np.linspace(0.0, 2.0 * SO_r, 100)
+            rrange = np.linspace(0.0 * unyt.kpc, 2.0 * SO_r, 100)
             Mrange = reference_density * 4.0 * np.pi / 3.0 * rrange ** 3
             rrange.convert_to_units("kpc")
             Mrange.convert_to_units("Msun")


### PR DESCRIPTION
Unyt deprecated a number of functions when version 3 was released. This PR mainly removes those deprecated functions.

There are also a small number of other changes:
- Change the files used by the check_subhalo_ranking.py
- Add rest frame Xray luminosities to the SO_properties test
- Update units in test_SO_radius_calculation.py
- Change the documentation table column widths