### PR TITLE
Fix SO_properties test and io_test

### DIFF
--- a/SO_properties.py
+++ b/SO_properties.py
@@ -1946,7 +1946,10 @@ def test_SO_properties():
                         input_data[ptype][dset] = data[ptype][dset]
             # Adding Restframe luminosties as they are calculated in halo_tasks
             if "PartType0" in input_data:
-                for dset in ["XrayLuminositiesRestframe", "XrayPhotonLuminositiesRestframe"]:
+                for dset in [
+                    "XrayLuminositiesRestframe",
+                    "XrayPhotonLuminositiesRestframe",
+                ]:
                     input_data["PartType0"][dset] = data["PartType0"][dset]
                     input_data["PartType0"][dset] = data["PartType0"][dset]
             input_halo_copy = input_halo.copy()

--- a/SO_properties.py
+++ b/SO_properties.py
@@ -1944,6 +1944,11 @@ def test_SO_properties():
                     input_data[ptype] = {}
                     for dset in prop_calc.particle_properties[ptype]:
                         input_data[ptype][dset] = data[ptype][dset]
+            # Adding Restframe luminosties as they are calculated in halo_tasks
+            if "PartType0" in input_data:
+                for dset in ["XrayLuminositiesRestframe", "XrayPhotonLuminositiesRestframe"]:
+                    input_data["PartType0"][dset] = data["PartType0"][dset]
+                    input_data["PartType0"][dset] = data["PartType0"][dset]
             input_halo_copy = input_halo.copy()
             input_data_copy = input_data.copy()
             prop_calc.calculate(input_halo, rmax, input_data, halo_result)

--- a/io_test.py
+++ b/io_test.py
@@ -20,8 +20,14 @@ def io_test():
     t0 = time.time()
 
     # Open the snapshot
-    fname = "/cosma8/data/dp004/flamingo/Runs/L2800N5040/HYDRO_FIDUCIAL/snapshots/flamingo_0037/flamingo_0037.%(file_nr)d.hdf5"
-    cellgrid = swift_cells.SWIFTCellGrid(fname)
+    fname = "/cosma8/data/dp004/flamingo/Runs/L1000N0900/HYDRO_FIDUCIAL/snapshots/flamingo_0037/flamingo_0037.%(file_nr)d.hdf5"
+    try:
+        cellgrid = swift_cells.SWIFTCellGrid(fname)
+    except FileNotFoundError:
+        if comm_rank == 0:
+            print('File not found for running io_test')
+        return
+
 
     # Quantities to read
     property_names = {
@@ -30,13 +36,13 @@ def io_test():
     }
 
     # Specify region to read
-    pos_min = np.asarray((0.0, 0.0, 0.0)) * cellgrid.units.length
-    pos_max = np.asarray((50.0, 50.0, 50.0)) * cellgrid.units.length
+    pos_min = np.asarray((0.0, 0.0, 0.0)) * cellgrid.get_unit('snap_length')
+    pos_max = np.asarray((50.0, 50.0, 50.0)) * cellgrid.get_unit('snap_length')
 
     # Read in the region
     mask = cellgrid.empty_mask()
     cellgrid.mask_region(mask, pos_min, pos_max)
-    data = cellgrid.read_masked_cells_to_shared_memory(property_names, mask, comm)
+    data = cellgrid.read_masked_cells_to_shared_memory(property_names, mask, comm, 8)
 
     comm.barrier()
     t1 = time.time()
@@ -65,24 +71,32 @@ def io_test():
     if comm_rank == 0:
 
         # Plot all particles
-        pos = data["PartType1"]["Coordinates"].full
-        plt.plot(pos[:, 0], pos[:, 1], "k,", alpha=0.05)
+        pos = data["PartType1"]["Coordinates"]
+        plt.plot(pos.full[:, 0], pos.full[:, 1], "k,", alpha=0.05)
         plt.gca().set_aspect("equal")
 
         # Use the mesh to plot a sub-region
-        pos_min = np.asarray((20, 20, 20), dtype=float) * cellgrid.units.length
-        pos_max = np.asarray((40, 40, 40), dtype=float) * cellgrid.units.length
+        pos_min = np.asarray((20, 20, 20), dtype=float) * cellgrid.get_unit('snap_length')
+        pos_max = np.asarray((40, 40, 40), dtype=float) * cellgrid.get_unit('snap_length')
         idx = mesh.query(pos_min, pos_max)
-        plt.plot(pos[idx, 0], pos[idx, 1], "r,")
+        plt.plot(pos.full[idx, 0], pos.full[idx, 1], "r,")
 
         # Try selecting a sphere
-        centre = np.asarray((30, 30, 30)) * cellgrid.units.length
-        radius = 10 * cellgrid.units.length
+        centre = np.asarray((30, 30, 30)) * cellgrid.get_unit('snap_length')
+        radius = 10 * cellgrid.get_unit('snap_length')
         idx = mesh.query_radius(centre, radius, pos)
-        plt.plot(pos[idx, 0], pos[idx, 1], "g,")
+        plt.plot(pos.full[idx, 0], pos.full[idx, 1], "g,")
 
-        plt.show()
+        plt.xlim(0, 150)
+        plt.ylim(0, 150)
+        plt.savefig(f"io_test.png", dpi=300)
+        plt.close()
 
+    # Free the shared particle data
+    for ptype in data:
+        for name in data[ptype]:
+            data[ptype][name].free()
+    mesh.free()
 
 if __name__ == "__main__":
     io_test()

--- a/io_test.py
+++ b/io_test.py
@@ -25,9 +25,8 @@ def io_test():
         cellgrid = swift_cells.SWIFTCellGrid(fname)
     except FileNotFoundError:
         if comm_rank == 0:
-            print('File not found for running io_test')
+            print("File not found for running io_test")
         return
-
 
     # Quantities to read
     property_names = {
@@ -36,8 +35,8 @@ def io_test():
     }
 
     # Specify region to read
-    pos_min = np.asarray((0.0, 0.0, 0.0)) * cellgrid.get_unit('snap_length')
-    pos_max = np.asarray((50.0, 50.0, 50.0)) * cellgrid.get_unit('snap_length')
+    pos_min = np.asarray((0.0, 0.0, 0.0)) * cellgrid.get_unit("snap_length")
+    pos_max = np.asarray((50.0, 50.0, 50.0)) * cellgrid.get_unit("snap_length")
 
     # Read in the region
     mask = cellgrid.empty_mask()
@@ -76,14 +75,18 @@ def io_test():
         plt.gca().set_aspect("equal")
 
         # Use the mesh to plot a sub-region
-        pos_min = np.asarray((20, 20, 20), dtype=float) * cellgrid.get_unit('snap_length')
-        pos_max = np.asarray((40, 40, 40), dtype=float) * cellgrid.get_unit('snap_length')
+        pos_min = np.asarray((20, 20, 20), dtype=float) * cellgrid.get_unit(
+            "snap_length"
+        )
+        pos_max = np.asarray((40, 40, 40), dtype=float) * cellgrid.get_unit(
+            "snap_length"
+        )
         idx = mesh.query(pos_min, pos_max)
         plt.plot(pos.full[idx, 0], pos.full[idx, 1], "r,")
 
         # Try selecting a sphere
-        centre = np.asarray((30, 30, 30)) * cellgrid.get_unit('snap_length')
-        radius = 10 * cellgrid.get_unit('snap_length')
+        centre = np.asarray((30, 30, 30)) * cellgrid.get_unit("snap_length")
+        radius = 10 * cellgrid.get_unit("snap_length")
         idx = mesh.query_radius(centre, radius, pos)
         plt.plot(pos.full[idx, 0], pos.full[idx, 1], "g,")
 
@@ -97,6 +100,7 @@ def io_test():
         for name in data[ptype]:
             data[ptype][name].free()
     mesh.free()
+
 
 if __name__ == "__main__":
     io_test()

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+python3 -W error -m pytest aperture_properties.py
+python3 -W error -m pytest half_mass_radius.py
+python3 -W error -m pytest projected_aperture_properties.py
+python3 -W error -m pytest SO_properties.py
+python3 -W error -m pytest subhalo_properties.py
+
+# Tests that won't run with pytest
+python3 test_SO_radius_calculation.py
+mpirun -np 8 python3 ./shared_mesh.py
+mpirun -np 8 python3 ./io_test.py

--- a/shared_mesh.py
+++ b/shared_mesh.py
@@ -44,6 +44,7 @@ class SharedMesh:
 
         # Then we can evaluate the minimum and maximum coordinates across
         # ranks which have particles with an allreduce.
+        # Multiplication by 1 is needed because of https://github.com/SWIFTSIM/SOAP/pull/58
         self.pos_min = np.empty_like(pos_min_local * 1)
         comm.Allreduce(pos_min_local * 1, self.pos_min, op=MPI.MIN)
         self.pos_max = np.empty_like(pos_max_local * 1)

--- a/shared_mesh.py
+++ b/shared_mesh.py
@@ -44,10 +44,10 @@ class SharedMesh:
 
         # Then we can evaluate the minimum and maximum coordinates across
         # ranks which have particles with an allreduce.
-        self.pos_min = np.empty_like(pos_min_local*1)
-        comm.Allreduce(pos_min_local*1, self.pos_min, op=MPI.MIN)
-        self.pos_max = np.empty_like(pos_max_local*1)
-        comm.Allreduce(pos_max_local*1, self.pos_max, op=MPI.MAX)
+        self.pos_min = np.empty_like(pos_min_local * 1)
+        comm.Allreduce(pos_min_local * 1, self.pos_min, op=MPI.MIN)
+        self.pos_max = np.empty_like(pos_max_local * 1)
+        comm.Allreduce(pos_max_local * 1, self.pos_max, op=MPI.MAX)
         assert np.all(pos.local >= self.pos_min)
         assert np.all(pos.local <= self.pos_max)
 

--- a/shared_mesh.py
+++ b/shared_mesh.py
@@ -44,10 +44,10 @@ class SharedMesh:
 
         # Then we can evaluate the minimum and maximum coordinates across
         # ranks which have particles with an allreduce.
-        self.pos_min = np.empty_like(pos_min_local)
-        comm.Allreduce(pos_min_local, self.pos_min, op=MPI.MIN)
-        self.pos_max = np.empty_like(pos_max_local)
-        comm.Allreduce(pos_max_local, self.pos_max, op=MPI.MAX)
+        self.pos_min = np.empty_like(pos_min_local*1)
+        comm.Allreduce(pos_min_local*1, self.pos_min, op=MPI.MIN)
+        self.pos_max = np.empty_like(pos_max_local*1)
+        comm.Allreduce(pos_max_local*1, self.pos_max, op=MPI.MAX)
         assert np.all(pos.local >= self.pos_min)
         assert np.all(pos.local <= self.pos_max)
 

--- a/swift_units.py
+++ b/swift_units.py
@@ -13,7 +13,9 @@ def unit_registry_from_snapshot(snap):
         name: float(value[0])
         for name, value in snap["PhysicalConstants/CGS"].attrs.items()
     }
-    cosmology = {name: float(value[0]) for name, value in snap["Cosmology"].attrs.items()}
+    cosmology = {
+        name: float(value[0]) for name, value in snap["Cosmology"].attrs.items()
+    }
     a = unyt.unyt_quantity(cosmology["Scale-factor"])
     h = unyt.unyt_quantity(cosmology["h"])
 

--- a/swift_units.py
+++ b/swift_units.py
@@ -10,10 +10,10 @@ def unit_registry_from_snapshot(snap):
 
     # Read snapshot metadata
     physical_constants_cgs = {
-        name: float(value)
+        name: float(value[0])
         for name, value in snap["PhysicalConstants/CGS"].attrs.items()
     }
-    cosmology = {name: float(value) for name, value in snap["Cosmology"].attrs.items()}
+    cosmology = {name: float(value[0]) for name, value in snap["Cosmology"].attrs.items()}
     a = unyt.unyt_quantity(cosmology["Scale-factor"])
     h = unyt.unyt_quantity(cosmology["h"])
 
@@ -23,7 +23,7 @@ def unit_registry_from_snapshot(snap):
     # Define code and snapshot base units
     for group_name, prefix in (("Units", "snap"), ("InternalCodeUnits", "code")):
         units_cgs = {
-            name: float(value) for name, value in snap[group_name].attrs.items()
+            name: float(value[0]) for name, value in snap[group_name].attrs.items()
         }
         unyt.define_unit(
             prefix + "_length",

--- a/test_SO_radius_calculation.py
+++ b/test_SO_radius_calculation.py
@@ -16,7 +16,7 @@ def test_SO_radius_calculation():
     np.random.seed(62)
 
     npart_choices = np.array([10, 100, 1000])
-    for i in range(100):
+    for i in range(50):
         npart = np.random.choice(npart_choices)
         Mpart = 1.0e9 * unyt.Msun
 
@@ -100,6 +100,7 @@ def test_SO_radius_calculation():
             ax[0][0].set_title("Success")
         else:
             ax[0][0].set_title("Failure")
+            print(f"{i:03d} SO calculation failed")
 
         pl.tight_layout()
         pl.savefig(f"test_SO_radius_{i:03d}.png", dpi=300)


### PR DESCRIPTION
This PR contains a couple of test fixes for https://github.com/SWIFTSIM/SOAP/issues/53 and https://github.com/SWIFTSIM/SOAP/issues/57. I've also added a script that will run all the tests, since some need to be run with mpi instead of with pytest.

https://github.com/SWIFTSIM/SOAP/issues/57 was an MPI error.  I've added a fix, but I'm not sure what was causing the problem. The error is only thrown when I run io_test.py, I'm not able to trigger it when I actually run SOAP. If I multiply the array by 1 the error doesn't occur. Inserting the following code in shared_mesh.py
```
a = pos_min_local.value * 1
b = pos_min_local.value
print('Array equal:', np.array_equal(a, b))
print('Array dtypes:', a.dtype, b.dtype)
print(a.flags, '\n', b.flags)
c = np.empty_like(a)
try:
    comm.Allreduce(b, c, op=MPI.MIN)
except KeyError:
    traceback.print_exc()
    comm.Allreduce(a, c, op=MPI.MIN)
    print('a was reduced, b was not')
```
gives the following output:
```
Array equal: True
Array dtypes: float64 float64
  C_CONTIGUOUS : True
  F_CONTIGUOUS : True
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False
  UPDATEIFCOPY : False
 
   C_CONTIGUOUS : True
  F_CONTIGUOUS : True
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False
  UPDATEIFCOPY : False

Traceback (most recent call last):
  File "/cosma/home/dp004/dc-mcgi1/clean/SOAP/shared_mesh.py", line 53, in __init__
    comm.Allreduce(b, c, op=MPI.MIN)
  File "mpi4py/MPI/Comm.pyx", line 876, in mpi4py.MPI.Comm.Allreduce
  File "mpi4py/MPI/msgbuffer.pxi", line 754, in mpi4py.MPI._p_msg_cco.for_allreduce
  File "mpi4py/MPI/msgbuffer.pxi", line 692, in mpi4py.MPI._p_msg_cco.for_cro_send
  File "mpi4py/MPI/msgbuffer.pxi", line 203, in mpi4py.MPI.message_simple
  File "mpi4py/MPI/msgbuffer.pxi", line 145, in mpi4py.MPI.message_basic
KeyError: '<d'
a was reduced, b was not
```