### PR TITLE
Only calculate large apertures for large halos

### DIFF
--- a/SO_properties.py
+++ b/SO_properties.py
@@ -2771,13 +2771,13 @@ class RadiusMultipleSOProperties(SOProperties):
                 "SOs with a radius that is a multiple of another SO radius are only allowed for type mean or crit!"
             )
 
-        # initialise the SOProperties object using a conservative physical radius estimate
+        # initialise the SOProperties object
         super().__init__(
             cellgrid,
             parameters,
             recently_heated_gas_filter,
             category_filter,
-            3000.0,
+            0,
             "physical",
         )
 
@@ -2901,7 +2901,7 @@ def test_SO_properties_random_halo():
             Npart,
             particle_numbers,
         ) = dummy_halos.get_random_halo([2, 10, 100, 1000, 10000], has_neutrinos=True)
-        halo_result_template = dummy_halos.get_halo_result_template(particle_numbers)
+        halo_result_template = dummy_halos.get_halo_result_template(particle_numbers, Mtot)
         rho_ref = Mtot / (4.0 / 3.0 * np.pi * rmax ** 3)
 
         # force the SO radius to be outside the search sphere and check that
@@ -3064,40 +3064,7 @@ def test_SO_properties_random_halo():
             "mean",
         )
 
-        halo_result_template = {
-            f"BoundSubhaloProperties/{PropertyTable.full_property_list['Ngas'][0]}": (
-                unyt.unyt_array(
-                    particle_numbers["PartType0"],
-                    dtype=PropertyTable.full_property_list["Ngas"][2],
-                    units="dimensionless",
-                ),
-                "Dummy Ngas for filter",
-            ),
-            f"BoundSubhaloProperties/{PropertyTable.full_property_list['Ndm'][0]}": (
-                unyt.unyt_array(
-                    particle_numbers["PartType1"],
-                    dtype=PropertyTable.full_property_list["Ndm"][2],
-                    units="dimensionless",
-                ),
-                "Dummy Ndm for filter",
-            ),
-            f"BoundSubhaloProperties/{PropertyTable.full_property_list['Nstar'][0]}": (
-                unyt.unyt_array(
-                    particle_numbers["PartType4"],
-                    dtype=PropertyTable.full_property_list["Nstar"][2],
-                    units="dimensionless",
-                ),
-                "Dummy Nstar for filter",
-            ),
-            f"BoundSubhaloProperties/{PropertyTable.full_property_list['Nbh'][0]}": (
-                unyt.unyt_array(
-                    particle_numbers["PartType5"],
-                    dtype=PropertyTable.full_property_list["Nbh"][2],
-                    units="dimensionless",
-                ),
-                "Dummy Nbh for filter",
-            ),
-        }
+        halo_result_template = dummy_halos.get_halo_result_template(particle_numbers, Mtot)
         rho_ref = Mtot / (4.0 / 3.0 * np.pi * rmax ** 3)
 
         # force the SO radius to be within the search sphere
@@ -3209,40 +3176,7 @@ def test_SO_properties_random_halo():
             "mean",
         )
 
-        halo_result_template = {
-            f"BoundSubhaloProperties/{PropertyTable.full_property_list['Ngas'][0]}": (
-                unyt.unyt_array(
-                    particle_numbers["PartType0"],
-                    dtype=PropertyTable.full_property_list["Ngas"][2],
-                    units="dimensionless",
-                ),
-                "Dummy Ngas for filter",
-            ),
-            f"BoundSubhaloProperties/{PropertyTable.full_property_list['Ndm'][0]}": (
-                unyt.unyt_array(
-                    particle_numbers["PartType1"],
-                    dtype=PropertyTable.full_property_list["Ndm"][2],
-                    units="dimensionless",
-                ),
-                "Dummy Ndm for filter",
-            ),
-            f"BoundSubhaloProperties/{PropertyTable.full_property_list['Nstar'][0]}": (
-                unyt.unyt_array(
-                    particle_numbers["PartType4"],
-                    dtype=PropertyTable.full_property_list["Nstar"][2],
-                    units="dimensionless",
-                ),
-                "Dummy Nstar for filter",
-            ),
-            f"BoundSubhaloProperties/{PropertyTable.full_property_list['Nbh'][0]}": (
-                unyt.unyt_array(
-                    particle_numbers["PartType5"],
-                    dtype=PropertyTable.full_property_list["Nbh"][2],
-                    units="dimensionless",
-                ),
-                "Dummy Nbh for filter",
-            ),
-        }
+        halo_result_template = dummy_halos.get_halo_result_template(particle_numbers, Mtot)
         rho_ref = Mtot / (4.0 / 3.0 * np.pi * rmax ** 3)
 
         # force the SO radius to be within the search sphere
@@ -3345,7 +3279,7 @@ def calculate_SO_properties_nfw_halo(seed, num_part, c):
         100, c, num_part
     )
 
-    halo_result_template = dummy_halos.get_halo_result_template(particle_numbers)
+    halo_result_template = dummy_halos.get_halo_result_template(particle_numbers, Mtot)
 
     property_calculator_200crit.nu_density *= 0
     property_calculator_200crit.calculate(input_halo, rmax, data, halo_result_template)

--- a/combine_args.py
+++ b/combine_args.py
@@ -55,6 +55,8 @@ def combine_arguments(command_line_args, config_file):
             for name in config_file_args[section]:
                 if isinstance(config_file_args[section][name], str):
                     all_args[section][name] = pf.format(config_file_args[section][name], **format_values)
+                elif not isinstance(config_file_args[section][name], dict):
+                    all_args[section][name] = config_file_args[section][name]
 
     return all_args
     

--- a/combine_chunks.py
+++ b/combine_chunks.py
@@ -114,6 +114,11 @@ def combine_chunks(
                 attrs.update(compression_metadata)
                 for attr_name, attr_value in attrs.items():
                     dataset.attrs[attr_name] = attr_value
+
+            # Add metadata for certain halo types
+            for halo_prop in halo_prop_list:
+                if halo_prop.description != '':
+                    outfile[halo_prop.group_name].attrs["Description"] = halo_prop.description
             outfile.close()
     comm_world.barrier()
 

--- a/combine_chunks.py
+++ b/combine_chunks.py
@@ -46,7 +46,7 @@ def combine_chunks(
 
     # Read the halo index from the scratch files and make a sorting index to put them in order
     with MPITimer("Establishing ID ordering of halos", comm_world):
-        halo_index = scratch_file.read("InputHalos/index")
+        halo_index = scratch_file.read("InputHalos/Index")
         order = psort.parallel_sort(halo_index, return_index=True, comm=comm_world)
         del halo_index
 

--- a/compression/compress_fast_metadata.py
+++ b/compression/compress_fast_metadata.py
@@ -16,7 +16,7 @@ with open(f"{script_folder}/wrong_compression.yml", "r") as cfile:
     compression_fixes = yaml.safe_load(cfile)
 
 chunksize = 1000
-compression_opts = {"compression": "gzip", "compression_opts": 9}
+compression_opts = {"compression": "gzip", "compression_opts": 4}
 
 
 class H5visiter:

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -232,6 +232,7 @@ def compute_halo_properties():
                     recently_heated_gas_filter,
                     category_filter,
                     SO_variations[variation]["value"],
+                    float(SO_variations[variation].get("mass_limit_msun", 0)),
                     SO_variations[variation]["type"],
                     core_excision_fraction=SO_variations[variation][
                         "core_excision_fraction"
@@ -246,6 +247,7 @@ def compute_halo_properties():
                     recently_heated_gas_filter,
                     category_filter,
                     SO_variations[variation]["value"],
+                    float(SO_variations[variation].get("mass_limit_msun", 0)),
                     SO_variations[variation]["type"],
                 )
             )
@@ -263,6 +265,7 @@ def compute_halo_properties():
                     category_filter,
                     SO_variations[variation]["value"],
                     SO_variations[variation]["radius_multiple"],
+                    float(SO_variations[variation].get("mass_limit_msun", 0)),
                     SO_variations[variation]["type"],
                 )
             )

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -337,18 +337,6 @@ def compute_halo_properties():
     if comm_world_rank == 0 and args.output_parameters:
         parameter_file.write_parameters(args.output_parameters)
 
-    # Determine which calculations we're doing this time
-    if args.calculations is not None:
-
-        # Check we recognise all the names specified on the command line
-        all_names = [hp.name for hp in halo_prop_list]
-        for calc in args.calculations:
-            if calc not in all_names:
-                raise Exception("Don't recognise calculation name: %s" % calc)
-
-        # Filter out calculations which were not selected
-        halo_prop_list = [hp for hp in halo_prop_list if hp.name in args.calculations]
-
     if len(halo_prop_list) < 1:
         raise Exception("Must select at least one halo property calculation!")
 
@@ -427,6 +415,7 @@ def compute_halo_properties():
         halo_prop_list,
         args.chunks,
         args.halo_sizes_file.format(snap_nr=args.snapshot_nr),
+        args.min_read_radius_cmpc
     )
 
     # Generate the chunk task list

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -299,6 +299,7 @@ def compute_halo_properties():
                     stellar_age_calculator,
                     cold_dense_gas_filter,
                     category_filter,
+                    float(aperture_variations[variation].get("mass_limit_msun", 0)),
                 )
             )
         else:
@@ -311,6 +312,7 @@ def compute_halo_properties():
                     stellar_age_calculator,
                     cold_dense_gas_filter,
                     category_filter,
+                    float(aperture_variations[variation].get("mass_limit_msun", 0)),
                 )
             )
     projected_aperture_variations = parameter_file.get_halo_type_variations(

--- a/documentation/SOAP.tex
+++ b/documentation/SOAP.tex
@@ -37,7 +37,9 @@ that they halo finder has determined are bound to the subhalo. Subhalo propertie
 particles that are bound to the subhalo, and apply an additional radial cut (aperture). We use eight 
 different aperture radii (10, 30, 50, 100, 300, 500, 1000, 3000 kpc), so that every (sub-)halo has eight of 
 these. Exclusive sphere properties are contained within a group \verb+ExclusiveSphere/XXXkpc+, where 
-\verb+XXX+ is the corresponding aperture radius.
+\verb+XXX+ is the corresponding aperture radius. A mass limit can be specified in the parameter file,
+in which case only subhalos with a bound mass above the limit will have these properties calculated. The mass
+limit of an aperture is contained in the attributes of its group in the output file.
 
 \paragraph{Inclusive sphere quantities (IS)} use the same physical aperture radii as the exclusive sphere 
 quantities, but include all particles within the radius, regardless of their membership status. They are

--- a/dummy_halo_generator.py
+++ b/dummy_halo_generator.py
@@ -488,9 +488,10 @@ class DummyHaloGenerator:
         return self.dummy_cellgrid
 
     @staticmethod
-    def get_halo_result_template(particle_numbers):
+    def get_halo_result_template(particle_numbers, Mtot):
         """
-        Return a halo_result object which only contains the number of each particle type.
+        Return a halo_result object which only contains the number of each particle type,
+        and the total halo mass.
         """
         return {
             f"BoundSubhaloProperties/{PropertyTable.full_property_list['Ngas'][0]}": (
@@ -524,6 +525,14 @@ class DummyHaloGenerator:
                     units="dimensionless",
                 ),
                 "Dummy Nbh for filter",
+            ),
+            f"BoundSubhaloProperties/{PropertyTable.full_property_list['Mtot'][0]}": (
+                unyt.unyt_array(
+                    Mtot,
+                    dtype=PropertyTable.full_property_list["Mtot"][2],
+                    units=Mtot.units,
+                ),
+                "Dummy mass for aperture properties",
             ),
         }
 

--- a/halo_centres.py
+++ b/halo_centres.py
@@ -65,14 +65,6 @@ class SOCatalogue:
         # Get expansion factor as a float
         a = a_unit.base_value
 
-        # Find minimum physical radius to read in
-        physical_radius_mpc = 0.0
-        for halo_prop in halo_prop_list:
-            physical_radius_mpc = max(
-                physical_radius_mpc, halo_prop.physical_radius_mpc
-            )
-        physical_radius_mpc = unyt.unyt_quantity(physical_radius_mpc, units=swift_pmpc)
-
         # Read the input halo catalogue
         common_props = (
             "index",
@@ -151,6 +143,19 @@ class SOCatalogue:
         local_halo["read_radius"] = local_halo["search_radius"].copy()
         min_radius = 5.0 * swift_cmpc
         local_halo["read_radius"] = local_halo["read_radius"].clip(min=min_radius)
+
+        # Find minimum physical radius to read in
+        physical_radius_mpc = 0.0
+        for halo_prop in halo_prop_list:
+            # Skip halo_types with a nonzero mass limit
+            # Assume mass limit is large enough to exclude majority of halos
+            if hasattr(halo_prop, "mass_limit"):
+                if halo_prop.mass_limit > 0 * unyt.Msun:
+                    continue
+            physical_radius_mpc = max(
+                physical_radius_mpc, halo_prop.physical_radius_mpc
+            )
+        physical_radius_mpc = unyt.unyt_quantity(physical_radius_mpc, units=swift_pmpc)
 
         # Ensure that both the initial search radius and the radius to read in
         # are >= the minimum physical radius required by property calculations

--- a/halo_centres.py
+++ b/halo_centres.py
@@ -37,6 +37,7 @@ class SOCatalogue:
         halo_prop_list,
         nr_chunks,
         halo_size_file,
+        min_read_radius_cmpc,
     ):
         """
         This reads in the halo catalogue and stores the halo properties in a
@@ -141,7 +142,7 @@ class SOCatalogue:
 
         # Compute initial radius to read in about each halo
         local_halo["read_radius"] = local_halo["search_radius"].copy()
-        min_radius = 5.0 * swift_cmpc
+        min_radius = min_read_radius_cmpc * swift_cmpc
         local_halo["read_radius"] = local_halo["read_radius"].clip(min=min_radius)
 
         # Find minimum physical radius to read in

--- a/halo_properties.py
+++ b/halo_properties.py
@@ -34,3 +34,5 @@ class HaloProperty:
             "PartType5": cellgrid.baryon_softening,
             "PartType6": cellgrid.nu_softening,
         }  # Softening length of each particle type
+        self.group_name = ''  # Name of halo property in output hdf5 file
+        self.description = '' # Description for hdf5 group

--- a/halo_tasks.py
+++ b/halo_tasks.py
@@ -316,10 +316,12 @@ def process_single_halo(
             try:
                 props = PropertyTable.full_property_list[name]
             except KeyError:
+                full_name = name
                 description = "No description available"
             else:
+                full_name = props[0]
                 description = props[4]
-            halo_result[f"InputHalos/{name}"] = (input_halo[name], description)
+            halo_result[f"InputHalos/{full_name}"] = (input_halo[name], description)
 
     return halo_result
 

--- a/halo_tasks.py
+++ b/halo_tasks.py
@@ -313,13 +313,15 @@ def process_single_halo(
     # Store input halo quantites
     for name in input_halo:
         if name not in ("done", "task_id", "read_radius", "search_radius"):
+            full_name = name
             try:
                 props = PropertyTable.full_property_list[name]
             except KeyError:
-                full_name = name
                 description = "No description available"
             else:
-                full_name = props[0]
+                # Don't overwrite halo finder property names, e.g. don't want "VR/ID" replaced with "ID"
+                if '/' not in name:
+                    full_name = props[0]
                 description = props[4]
             halo_result[f"InputHalos/{full_name}"] = (input_halo[name], description)
 

--- a/parameter_files/COLIBRE.yml
+++ b/parameter_files/COLIBRE.yml
@@ -421,4 +421,5 @@ defined_constants:
   N_O_sun: 0.138
   C_O_sun: 0.549
 calculations:
-    recalculate_xrays: false
+  recalculate_xrays: false
+  min_read_radius_cmpc: 0.5

--- a/parameter_files/FLAMINGO.yml
+++ b/parameter_files/FLAMINGO.yml
@@ -155,6 +155,7 @@ ApertureProperties:
     exclusive_1000_kpc:
       inclusive: false
       radius_in_kpc: 1000.0
+      mass_limit_msun: 1e13
     exclusive_100_kpc:
       inclusive: false
       radius_in_kpc: 100.0
@@ -164,6 +165,7 @@ ApertureProperties:
     exclusive_3000kpc:
       inclusive: false
       radius_in_kpc: 3000.0
+      mass_limit_msun: 1e13
     exclusive_300kpc:
       inclusive: false
       radius_in_kpc: 300.0
@@ -179,6 +181,7 @@ ApertureProperties:
     inclusive_1000_kpc:
       inclusive: true
       radius_in_kpc: 1000.0
+      mass_limit_msun: 1e13
     inclusive_100_kpc:
       inclusive: true
       radius_in_kpc: 100.0
@@ -188,6 +191,7 @@ ApertureProperties:
     inclusive_3000kpc:
       inclusive: true
       radius_in_kpc: 3000.0
+      mass_limit_msun: 1e13
     inclusive_300kpc:
       inclusive: true
       radius_in_kpc: 300.0

--- a/parameter_files/FLAMINGO.yml
+++ b/parameter_files/FLAMINGO.yml
@@ -483,3 +483,4 @@ defined_constants:
 calculations:
   recalculate_xrays: true
   xray_table_path: /snap8/scratch/dp004/dc-bras1/cloudy/X_Ray_table_metals_full.hdf5
+  min_read_radius_cmpc: 3

--- a/property_table.py
+++ b/property_table.py
@@ -2845,7 +2845,7 @@ class PropertyTable:
             3,
             np.float64,
             "cMpc",
-            "Centre of potential. Used as reference for all relative positions. Equal to the position of the most bound particle in the subhalo.",
+            "The centre of the subhalo as given by the halo finder. Used as reference for all relative positions. For VR and HBTplus this is equal to the position of the most bound particle in the subhalo.",
             "Input",
             "DScale5",
             True,

--- a/property_table.py
+++ b/property_table.py
@@ -2841,7 +2841,7 @@ class PropertyTable:
         ),
         # InputHalo properties
         "cofp": (
-            "cofp",
+            "HaloCentre",
             3,
             np.float64,
             "cMpc",
@@ -2852,7 +2852,7 @@ class PropertyTable:
             [],
         ),
         "index": (
-            "index",
+            "Index",
             1,
             np.int64,
             "dimensionless",
@@ -2863,7 +2863,7 @@ class PropertyTable:
             [],
         ),
         "is_central": (
-            "is\_central",
+            "IsCentral",
             1,
             np.int64,
             "dimensionless",
@@ -2874,7 +2874,7 @@ class PropertyTable:
             [],
         ),
         "nr_bound_part": (
-            "nr\_bound\_part",
+            "NumberOfBoundParticles",
             1,
             np.int64,
             "dimensionless",

--- a/property_table.py
+++ b/property_table.py
@@ -2856,7 +2856,7 @@ class PropertyTable:
             1,
             np.int64,
             "dimensionless",
-            "Index of this halo in the original halo finder catalogue (first halo has index=0).",
+            "Index of this subhalo in the original halo finder catalogue. For HBT certain indices will be missing because the HBT catalogues contain orphan subhalos, but these are ignored by SOAP.",
             "Input",
             "None",
             True,

--- a/soap_args.py
+++ b/soap_args.py
@@ -31,7 +31,6 @@ def get_soap_args(comm):
     parser.add_argument("--centrals-only", action="store_true", help="Only process central halos")
     parser.add_argument("--max-halos", metavar="N", type=int, default=0, help="(For debugging) only process the first N halos in the catalogue")
     parser.add_argument("--halo-indices", nargs="*", type=int, help="Only process the specified halo indices")
-    parser.add_argument("--calculations", nargs="*", help="Which calculations to do (default is to do all)")
     parser.add_argument("--reference-snapshot", help="Specify reference snapshot number containing all particle types", metavar="N", type=int)
     parser.add_argument("--profile", metavar="LEVEL", type=int, default=0, help="Run with profiling (0=off, 1=first MPI rank only, 2=all ranks)")
     parser.add_argument("--max-ranks-reading", type=int, default=32, help="Number of ranks per node reading snapshot data")
@@ -62,12 +61,12 @@ def get_soap_args(comm):
     args.dmo = all_args["Parameters"]["dmo"]
     args.max_halos = all_args["Parameters"]["max_halos"]
     args.halo_indices = all_args["Parameters"]["halo_indices"]
-    args.calculations = all_args["Parameters"]["calculations"]
     args.reference_snapshot = all_args["Parameters"]["reference_snapshot"]
     args.profile = all_args["Parameters"]["profile"]
     args.max_ranks_reading = all_args["Parameters"]["max_ranks_reading"]
     args.output_parameters = all_args["Parameters"]["output_parameters"]
     args.git_hash = all_args["git_hash"]
+    args.min_read_radius_cmpc = all_args["calculations"]["min_read_radius_cmpc"]
 
     return args
 

--- a/tests/FLAMINGO/parameters.yml
+++ b/tests/FLAMINGO/parameters.yml
@@ -468,3 +468,4 @@ defined_constants:
 calculations:
   recalculate_xrays: true
   xray_table_path: /snap8/scratch/dp004/dc-bras1/cloudy/X_Ray_table_metals_full.hdf5
+  min_read_radius_cmpc: 3


### PR DESCRIPTION
In this PR I have added a mass limit to each aperture. The aperture will be skipped by subhalos which have a bound mass which is below the mass limit. This is motivated by the SOAP runtime for high z, which we think is due to the fact that the apertures are physical, and so become very large at early times.

This was implemented by adding a new parameter (mass_limit_msun) to the definition of the apertures in the parameter file. I then compare this value with `BoundSubhaloProperties/TotalMass` to determine whether to skip the aperture. We have to calculate `BoundSubhaloProperties` before we get to the apertures anyway since they are required for the filters to work. The skip is done in the same way that we skip non-centrals in `SO_properties`. The apertures can now throw a `ReadRadiusTooSmallError` if the search radius is too small. 

These changes affect the value that we pick for the initial read/search radius guess. The lower physical limit is now the largest aperture with no mass limit. I've moved the min_radius, which (sets the lower co-moving limit) to the parameter file. We shouldn't be using the same value for COLIBRE and FLAMINGO, and I also think it's more visible there for future users.

Other changes
- Use the `get_halo_result_template` function in tests rather than create a new template directly
- Remove the `calculations` argument. This was used to specify which halo types to calculate, but this functionality now exists with the parameter file. 
- Rename properties in `InputHalos` to be more human readable.

It's probably worth doing some further testing of good initial guesses for the search/read radius, as that could have a significant effect on the runtime.

This decreases the runtime for the N1800 box by a factor of 3 at `z=2` when a mass limit of 1e13 is used for the 1Mpc and 3Mpc apertures.