### PR TITLE
Squash bug when getting git hash

### DIFF
--- a/command_line_args.py
+++ b/command_line_args.py
@@ -18,7 +18,10 @@ class ThrowingArgumentParser(argparse.ArgumentParser):
 
 
 def get_git_hash() -> str:
-    return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
+    soap_folder = os.path.realpath(__file__).removesuffix("/command_line_args.py")
+    command = f"cd {soap_folder}; git rev-parse HEAD"
+    result = subprocess.run(command, capture_output=True, shell=True)
+    return result.stdout.decode().rstrip()
 
 
 def get_halo_props_args(comm):


### PR DESCRIPTION
Fetching the git hash was causing SOAP to crash if it wasn't being run from the SOAP repo. I've changed the subprocess so that it now moves to the SOAP repo.