### PR TITLE
Flamingo script updates

### DIFF
--- a/scripts/FLAMINGO/L1000N0900/group_membership_L1000N0900.sh
+++ b/scripts/FLAMINGO/L1000N0900/group_membership_L1000N0900.sh
@@ -14,7 +14,7 @@
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=1
 #SBATCH --tasks-per-node=128
-#SBATCH -o ./logs/group_membership_L1000N0900_%x.%a.%j.out
+#SBATCH -o ./logs/group_membership_L1000N0900_%x.%a.%A.out
 #SBATCH -p cosma8
 #SBATCH -A dp004
 #SBATCH --exclusive

--- a/scripts/FLAMINGO/L1000N0900/group_membership_L1000N0900.sh
+++ b/scripts/FLAMINGO/L1000N0900/group_membership_L1000N0900.sh
@@ -24,6 +24,8 @@
 module purge
 module load gnu_comp/11.1.0 openmpi/4.1.1 python/3.10.1
 
+set -e
+
 # Which snapshot to do
 snapnum=`printf '%04d' ${SLURM_ARRAY_TASK_ID}`
 

--- a/scripts/FLAMINGO/L1000N0900/halo_properties_L1000N0900.sh
+++ b/scripts/FLAMINGO/L1000N0900/halo_properties_L1000N0900.sh
@@ -37,7 +37,7 @@ if [[ $sim == *DMO_* ]] ; then
 fi
 
 mpirun python3 -u -m mpi4py ./compute_halo_properties.py \
-       --sim-name=${sim} --snap-nr=${snapnum} --chunks=1 ${dmo_flag} \
-       parameter_files/FLAMINGO.yml
+       --sim-name=${sim} --snap-nr=${snapnum} --reference-snapshot=77 \
+       --chunks=1 ${dmo_flag} parameter_files/FLAMINGO.yml
 
 echo "Job complete!"

--- a/scripts/FLAMINGO/L1000N0900/halo_properties_L1000N0900.sh
+++ b/scripts/FLAMINGO/L1000N0900/halo_properties_L1000N0900.sh
@@ -12,7 +12,7 @@
 #
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=1
-#SBATCH -o ./logs/halo_properties_L1000N0900_%x.%a.%j.out
+#SBATCH -o ./logs/halo_properties_L1000N0900_%x.%a.%A.out
 #SBATCH -p cosma8
 #SBATCH -A dp004
 #SBATCH --exclusive

--- a/scripts/FLAMINGO/L1000N0900/halo_properties_L1000N0900.sh
+++ b/scripts/FLAMINGO/L1000N0900/halo_properties_L1000N0900.sh
@@ -22,6 +22,8 @@
 module purge
 module load gnu_comp/11.1.0 openmpi/4.1.1 python/3.10.1
 
+set -e
+
 # Which snapshot to do
 snapnum=${SLURM_ARRAY_TASK_ID}
 

--- a/scripts/FLAMINGO/L1000N1800/group_membership_L1000N1800.sh
+++ b/scripts/FLAMINGO/L1000N1800/group_membership_L1000N1800.sh
@@ -14,7 +14,7 @@
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=1
 #SBATCH --tasks-per-node=128
-#SBATCH -o ./logs/group_membership_L1000N1800_%x.%a.%j.out
+#SBATCH -o ./logs/group_membership_L1000N1800_%x.%a.%A.out
 #SBATCH -p cosma8
 #SBATCH -A dp004
 #SBATCH --exclusive

--- a/scripts/FLAMINGO/L1000N1800/group_membership_L1000N1800.sh
+++ b/scripts/FLAMINGO/L1000N1800/group_membership_L1000N1800.sh
@@ -24,6 +24,8 @@
 module purge
 module load gnu_comp/11.1.0 openmpi/4.1.1 python/3.10.1
 
+set -e
+
 # Which snapshot to do
 snapnum=`printf '%04d' ${SLURM_ARRAY_TASK_ID}`
 

--- a/scripts/FLAMINGO/L1000N1800/halo_properties_L1000N1800.sh
+++ b/scripts/FLAMINGO/L1000N1800/halo_properties_L1000N1800.sh
@@ -37,7 +37,7 @@ if [[ $sim == *DMO_* ]] ; then
 fi
 
 mpirun python3 -u -m mpi4py ./compute_halo_properties.py \
-       --sim-name=${sim} --snap-nr=${snapnum} --chunks=4 ${dmo_flag} \
-       parameter_files/FLAMINGO.yml
+       --sim-name=${sim} --snap-nr=${snapnum} --reference-snapshot=77 \
+       --chunks=4 ${dmo_flag} parameter_files/FLAMINGO.yml
 
 echo "Job complete!"

--- a/scripts/FLAMINGO/L1000N1800/halo_properties_L1000N1800.sh
+++ b/scripts/FLAMINGO/L1000N1800/halo_properties_L1000N1800.sh
@@ -12,7 +12,7 @@
 #
 #SBATCH --nodes=4
 #SBATCH --cpus-per-task=1
-#SBATCH -o ./logs/halo_properties_L1000N1800_%x.%a.%j.out
+#SBATCH -o ./logs/halo_properties_L1000N1800_%x.%a.%A.out
 #SBATCH -p cosma8
 #SBATCH -A dp004
 #SBATCH --exclusive

--- a/scripts/FLAMINGO/L1000N1800/halo_properties_L1000N1800.sh
+++ b/scripts/FLAMINGO/L1000N1800/halo_properties_L1000N1800.sh
@@ -22,6 +22,8 @@
 module purge
 module load gnu_comp/11.1.0 openmpi/4.1.1 python/3.10.1
 
+set -e
+
 # Which snapshot to do
 snapnum=${SLURM_ARRAY_TASK_ID}
 

--- a/scripts/FLAMINGO/L1000N3600/group_membership_L1000N3600.sh
+++ b/scripts/FLAMINGO/L1000N3600/group_membership_L1000N3600.sh
@@ -14,7 +14,7 @@
 #SBATCH --nodes=8
 #SBATCH --cpus-per-task=1
 #SBATCH --tasks-per-node=32
-#SBATCH -o ./logs/group_membership_L1000N3600_%x.%a.%j.out
+#SBATCH -o ./logs/group_membership_L1000N3600_%x.%a.%A.out
 #SBATCH -p cosma8
 #SBATCH -A dp004
 #SBATCH --exclusive

--- a/scripts/FLAMINGO/L1000N3600/group_membership_L1000N3600.sh
+++ b/scripts/FLAMINGO/L1000N3600/group_membership_L1000N3600.sh
@@ -24,6 +24,8 @@
 module purge
 module load gnu_comp/11.1.0 openmpi/4.1.1 python/3.10.1
 
+set -e
+
 # Which snapshot to do
 snapnum=`printf '%04d' ${SLURM_ARRAY_TASK_ID}`
 

--- a/scripts/FLAMINGO/L1000N3600/halo_properties_L1000N3600.sh
+++ b/scripts/FLAMINGO/L1000N3600/halo_properties_L1000N3600.sh
@@ -37,7 +37,7 @@ if [[ $sim == *DMO_* ]] ; then
 fi
 
 mpirun python3 -u -m mpi4py ./compute_halo_properties.py \
-       --sim-name=${sim} --snap-nr=${snapnum} --chunks=80 ${dmo_flag} \
-       parameter_files/FLAMINGO.yml
+       --sim-name=${sim} --snap-nr=${snapnum} --reference-snapshot=78 \
+       --chunks=80 ${dmo_flag} parameter_files/FLAMINGO.yml
 
 echo "Job complete!"

--- a/scripts/FLAMINGO/L1000N3600/halo_properties_L1000N3600.sh
+++ b/scripts/FLAMINGO/L1000N3600/halo_properties_L1000N3600.sh
@@ -12,7 +12,7 @@
 #
 #SBATCH --nodes=40
 #SBATCH --cpus-per-task=1
-#SBATCH -o ./logs/halo_properties_L1000N3600_%x.%a.%j.out
+#SBATCH -o ./logs/halo_properties_L1000N3600_%x.%a.%A.out
 #SBATCH -p cosma8
 #SBATCH -A dp004
 #SBATCH --exclusive

--- a/scripts/FLAMINGO/L1000N3600/halo_properties_L1000N3600.sh
+++ b/scripts/FLAMINGO/L1000N3600/halo_properties_L1000N3600.sh
@@ -22,6 +22,8 @@
 module purge
 module load gnu_comp/11.1.0 openmpi/4.1.1 python/3.10.1
 
+set -e
+
 # Which snapshot to do
 snapnum=${SLURM_ARRAY_TASK_ID}
 

--- a/swift_cells.py
+++ b/swift_cells.py
@@ -159,7 +159,7 @@ class SWIFTCellGrid:
             if snap_filename_ref is None:
                 self.snapshot_datasets = SnapshotDatasets(infile)
             else:
-                with h5py.File(snap_filename_ref % {"file_nr": 0}, "r") as ref_file:
+                with h5py.File(snap_filename_ref.format(file_nr=0), "r") as ref_file:
                     self.snapshot_datasets = SnapshotDatasets(ref_file)
 
             # Get the snapshot unit system


### PR DESCRIPTION
A few small fixes for running on SOAP on FLAMINGO HBTplus output:

  * Scripts abort on failure without producing the "Job complete" message
  * Log file names changed so that elements of the same array job get the same job ID
  * Added --reference-snapshot parameter in halo properties script so that it works on early snapshots which are missing some particle types
  * Changed reference snapshot filename to use f-string style formatting for consistency