### PR TITLE
Add minimal parameter file for DMO runs

### DIFF
--- a/compression/compress_fast_metadata.py
+++ b/compression/compress_fast_metadata.py
@@ -16,7 +16,7 @@ with open(f"{script_folder}/wrong_compression.yml", "r") as cfile:
     compression_fixes = yaml.safe_load(cfile)
 
 chunksize = 1000
-compression_opts = {"compression": "gzip", "compression_opts": 9}
+compression_opts = {"compression": "gzip", "compression_opts": 4}
 
 
 class H5visiter:
@@ -92,7 +92,7 @@ def create_lossy_dataset(file, name, shape, filter):
     new_plist.set_chunk(chunk)
     for f in fprops["filters"]:
         new_plist.set_filter(f[0], f[1], tuple(f[2]))
-    new_plist.set_deflate(9)
+    new_plist.set_deflate(compression_opts["compression_opts"])
     space = h5py.h5s.create_simple(shape, shape)
     h5py.h5d.create(file.id, name.encode("utf-8"), type, space, new_plist, None).close()
 

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -353,6 +353,7 @@ def compute_halo_properties():
         else:
             print("for central and satellite halos")
         parameter_file.print_unregistered_properties()
+        parameter_file.print_invalid_properties()
         if parameter_file.recalculate_xrays():
             print(f"Recalculating xray properties using table: {parameter_file.get_xray_table_path()}")
         category_filter.print_filters()

--- a/documentation/SOAP.tex
+++ b/documentation/SOAP.tex
@@ -10,6 +10,7 @@
 \usepackage{xcolor}
 
 \input{filters}
+\input{variations}
 
 \title{SOAP -- Spherical Overdensity and Aperture Processor}
 \author{Bert Vandenbroucke, Joop Schaye, John Helly, Matthieu Schaller, Rob McGibbon}
@@ -75,10 +76,10 @@ These are stored in a separate group, \verb+SOAP+. This is just done for conveni
 \begin{longtable}{llcp{6cm}}
  & Name & Inclusive? & Variations \\
 \hline{}SH & \verb+BoundSubhaloProperties+ & \ding{53} & - \\
-ES & \verb+ExclusiveSphere/XXXkpc+ & \ding{53} & 30, 50, 100, 300, 500, 1000, 3000 kpc \\
-IS & \verb+InclusiveSphere/XXXkpc+ & \ding{51} & 30, 50, 100, 300, 500, 1000, 3000 kpc \\
-EP & \verb+ProjectedAperture/XXXkpc/projP+ & \ding{53} & 10, 30, 50, 100 kpc \\
-SO & \verb+SO/XXX+ & \ding{51} & 200 mean, (50, 100, 200, 500, 1000, 2500) crit, 5$\times{}$500 crit \\
+ES & \verb+ExclusiveSphere/XXXkpc+ & \ding{53} & \variationsES \\
+IS & \verb+InclusiveSphere/XXXkpc+ & \ding{51} & \variationsIS \\
+EP & \verb+ProjectedAperture/XXXkpc/projP+ & \ding{53} & \variationsEP \\
+SO & \verb+SO/XXX+ & \ding{51} & \variationsSO \\
 - & \verb+InputHalos/+ & - & Directly copied from halo catalogue \\
 - & \verb+SOAP/+ & - & Computed from other halo properties \\
 \end{longtable}
@@ -271,7 +272,7 @@ The GroupNr values stored here are zero based array indexes into the
 full VR halo catalogue, and not VELOCIraptor IDs (which start from
 one). The first group in the catalogue will have GroupNr=0 and ID=1.
 
-The script `make_virtual_snapshot.py` will combine snapshot and group membership files 
+The script make\_virtual\_snapshot.py will combine snapshot and group membership files
 into a single virtual snapshot file. This virtual file can be read by swiftsimio and 
 gadgetviewer to provide halo membership information alongside other particle properties.
 Using the virtual file along with the spatial masking functionality within swiftsimio

--- a/documentation/SOAP.tex
+++ b/documentation/SOAP.tex
@@ -10,7 +10,6 @@
 \usepackage{xcolor}
 
 \input{filters}
-\input{variations}
 
 \title{SOAP -- Spherical Overdensity and Aperture Processor}
 \author{Bert Vandenbroucke, Joop Schaye, John Helly, Matthieu Schaller, Rob McGibbon}
@@ -75,11 +74,11 @@ These are stored in a separate group, \verb+SOAP+. This is just done for conveni
 
 \begin{longtable}{llcp{6cm}}
  & Name & Inclusive? & Variations \\
-\hline{}SH & \verb+BoundSubhaloProperties+ & \ding{53} & - \\
-ES & \verb+ExclusiveSphere/XXXkpc+ & \ding{53} & \variationsES \\
-IS & \verb+InclusiveSphere/XXXkpc+ & \ding{51} & \variationsIS \\
-EP & \verb+ProjectedAperture/XXXkpc/projP+ & \ding{53} & \variationsEP \\
-SO & \verb+SO/XXX+ & \ding{51} & \variationsSO \\
+\hline{}SH & \verb+BoundSubhalo+ & \ding{53} & - \\
+ES & \verb+ExclusiveSphere/XXXkpc+ & \ding{53} & 30, 50, 100, 300, 500, 1000, 3000 kpc \\
+IS & \verb+InclusiveSphere/XXXkpc+ & \ding{51} & 30, 50, 100, 300, 500, 1000, 3000 kpc \\
+EP & \verb+ProjectedAperture/XXXkpc/projP+ & \ding{53} & 10, 30, 50, 100 kpc \\
+SO & \verb+SO/XXX+ & \ding{51} & 200 mean, (50, 100, 200, 500, 1000, 2500) crit, 5$\times{}$500 crit \\
 - & \verb+InputHalos/+ & - & Directly copied from halo catalogue \\
 - & \verb+SOAP/+ & - & Computed from other halo properties \\
 \end{longtable}
@@ -279,7 +278,7 @@ The GroupNr values stored here are zero based array indexes into the
 full subhalo catalogue, and not the subhalos IDs. For example the first group
 in the VELOCIraptor catalogue has GroupNr=0 and ID=1.
 
-The script make\_virtual\_snapshot.py will combine snapshot and group membership files
+The script `make_virtual_snapshot.py` will combine snapshot and group membership files 
 into a single virtual snapshot file. This virtual file can be read by swiftsimio and 
 gadgetviewer to provide halo membership information alongside other particle properties.
 Using the virtual file along with the spatial masking functionality within swiftsimio

--- a/documentation/footnote_spin.tex
+++ b/documentation/footnote_spin.tex
@@ -6,5 +6,5 @@
 
 where $\vec{L}_{\rm{}tot}$ is the total angular momentum of all particles within radius $R$, and $M$ their 
 total mass. The angular momentum is computed relative to the centre of potential and the total centre of mass 
-velocity. Since subhalos do not have a natural radius associated with them, we use the radius where 
+velocity. Since subhalos do not have a natural radius associated with them, we use the radius where the softened
 $v_{\rm{}max}$ is reached.

--- a/parameter_file.py
+++ b/parameter_file.py
@@ -82,9 +82,10 @@ and can output this information in the form of a ".used_parameters" file,
 similar to the file produced by SWIFT.
 """
 
-import yaml
 from typing import Dict, Union, List, Tuple
+import yaml
 
+import property_table
 
 class ParameterFile:
     """
@@ -199,6 +200,27 @@ class ParameterFile:
             )
             for halo_type, property in self.unregistered_parameters:
                 print(f"  {halo_type.ljust(30)}{property}")
+
+    def print_invalid_properties(self) -> None:
+        """
+        Print a list of any properties in the parameter file that are not present in
+        the property table. This doesn't check if the property is defined for a specific
+        halo type.
+        """
+        invalid_properties = []
+        full_property_list = property_table.PropertyTable.full_property_list
+        valid_properties = [prop[0] for prop in full_property_list.values()]
+        for key in self.parameters:
+            # Skip keys which aren't halo types
+            if 'properties' not in self.parameters[key]:
+                continue
+            for prop in self.parameters[key]['properties']:
+                if prop not in valid_properties:
+                    invalid_properties.append(prop)
+        if len(invalid_properties):
+            print('The following properties were found in the parameter file, but are invalid:')
+            for prop in invalid_properties:
+                print(f"  {prop}")
 
     def get_halo_type_variations(
         self, halo_type: str, default_variations: Dict

--- a/parameter_files/COLIBRE.yml
+++ b/parameter_files/COLIBRE.yml
@@ -419,4 +419,5 @@ defined_constants:
   N_O_sun: 0.138
   C_O_sun: 0.549
 calculations:
-    recalculate_xrays: false
+  recalculate_xrays: false
+  calculate_missing_properties: true

--- a/parameter_files/FLAMINGO.yml
+++ b/parameter_files/FLAMINGO.yml
@@ -479,3 +479,4 @@ defined_constants:
 calculations:
   recalculate_xrays: true
   xray_table_path: /snap8/scratch/dp004/dc-bras1/cloudy/X_Ray_table_metals_full.hdf5
+  calculate_missing_properties: true

--- a/parameter_files/FLAMINGO.yml
+++ b/parameter_files/FLAMINGO.yml
@@ -273,8 +273,12 @@ SOProperties:
     CentreOfMassVelocity: true
     ComptonY: true
     ComptonYWithoutRecentAGNHeating: true
+    Concentration: true
+    ConcentrationSoft: true
     DarkMatterInertiaTensor: true
     DarkMatterMass: true
+    DarkMatterConcentration: true
+    DarkMatterConcentrationSoft: true
     DiscToTotalGasMassFraction: true
     DiscToTotalStellarMassFraction: true
     DopplerB: true
@@ -302,6 +306,7 @@ SOProperties:
     KineticEnergyGas: true
     KineticEnergyStars: true
     MassFractionSatellites: true
+    MassFractionExternal: true
     MostMassiveBlackHoleAccretionRate: true
     MostMassiveBlackHoleID: true
     MostMassiveBlackHoleLastEventScalefactor: true
@@ -427,6 +432,7 @@ SubhaloProperties:
     MassWeightedMeanStellarAge: true
     MaximumCircularVelocity: true
     MaximumCircularVelocityRadius: true
+    MaximumCircularVelocitySoft: true
     MaximumDarkMatterCircularVelocity: true
     MaximumDarkMatterCircularVelocityRadius: true
     MedianStellarBirthDensity: false

--- a/parameter_files/MINIMAL_DMO_FLAMINGO.yml
+++ b/parameter_files/MINIMAL_DMO_FLAMINGO.yml
@@ -42,7 +42,7 @@ SOProperties:
     CentreOfMassVelocity: true
     Concentration: true
     ConcentrationSoft: true
-    MassFractionSatellite: true
+    MassFractionSatellites: true
     MassFractionExternal: true
     NumberOfDarkMatterParticles: true
     SORadius: true
@@ -64,7 +64,7 @@ SubhaloProperties:
     CentreOfMassVelocity: true
     NumberOfDarkMatterParticles: true
     MaximumCircularVelocity: true
-    MaximumCircularVelocitySOFT: true
+    MaximumCircularVelocitySoft: true
     MaximumCircularVelocityRadius: true
     SpinParameter: true
     TotalMass: true

--- a/parameter_files/MINIMAL_DMO_FLAMINGO.yml
+++ b/parameter_files/MINIMAL_DMO_FLAMINGO.yml
@@ -1,0 +1,83 @@
+# Values in this section are substituted into the other sections
+# The simulation name (box size and resolution) and snapshot will be appended
+# to these to get the full name of the input/output files/directories
+Parameters:
+  sim_dir: /cosma8/data/dp004/flamingo/Runs
+  output_dir: /cosma8/data/dp004/dc-mcgi1/flamingo/Runs
+  scratch_dir: /snap8/scratch/dp004/dc-mcgi1/flamingo/Runs
+
+# Location of the Swift snapshots:
+Snapshots:
+  # Use {snap_nr:04d} for the snapshot number and {file_nr} for the file number.
+  filename: "{sim_dir}/{sim_name}/snapshots/flamingo_{snap_nr:04d}/flamingo_{snap_nr:04d}.{file_nr}.hdf5"
+
+# Which halo finder we're using, and base name for halo finder output files
+HaloFinder:
+  type: HBTplus
+  filename: "{sim_dir}/{sim_name}/HBTplus/{snap_nr:03d}/SubSnap_{snap_nr:03d}"
+
+GroupMembership:
+  # Where to write the group membership files
+  filename: "{output_dir}/{sim_name}/SOAP_uncompressed/{halo_finder}/membership_{snap_nr:04d}/membership_{snap_nr:04d}.{file_nr}.hdf5"
+
+HaloProperties:
+  # Where to write the halo properties file
+  filename: "{output_dir}/{sim_name}/SOAP_uncompressed/{halo_finder}/halo_properties_{snap_nr:04d}.hdf5"
+  # Where to write temporary chunk output
+  chunk_dir: "{scratch_dir}/{sim_name}/SOAP-tmp/{halo_finder}/"
+
+ApertureProperties:
+  properties:
+    {}
+  variations:
+    {}
+ProjectedApertureProperties:
+  properties:
+    {}
+  variations:
+    {}
+SOProperties:
+  properties:
+    CentreOfMass: true
+    CentreOfMassVelocity: true
+    Concentration: true
+    ConcentrationSoft: true
+    MassFractionSatellite: true
+    MassFractionExternal: true
+    NumberOfDarkMatterParticles: true
+    SORadius: true
+    SpinParameter: true
+    TotalMass: true
+  variations:
+    200_crit:
+      type: crit
+      value: 200.0
+    200_mean:
+      type: mean
+      value: 200.0
+    500_crit:
+      type: crit
+      value: 500.0
+SubhaloProperties:
+  properties:
+    CentreOfMass: true
+    CentreOfMassVelocity: true
+    NumberOfDarkMatterParticles: true
+    NumberOfBlackHoleParticles: true
+    MaximumCircularVelocity: true
+    MaximumCircularVelocitySOFT: true
+    MaximumCircularVelocityRadius: true
+    SpinParameter: true
+    TotalMass: true
+  variations:
+    Bound:
+      bound_only: true
+filters:
+  baryon: 100
+  dm: 100
+  gas: 100
+  general: 100
+  star: 100
+calculations:
+  recalculate_xrays: false
+  calculate_missing_properties: false

--- a/parameter_files/MINIMAL_DMO_FLAMINGO.yml
+++ b/parameter_files/MINIMAL_DMO_FLAMINGO.yml
@@ -63,7 +63,6 @@ SubhaloProperties:
     CentreOfMass: true
     CentreOfMassVelocity: true
     NumberOfDarkMatterParticles: true
-    NumberOfBlackHoleParticles: true
     MaximumCircularVelocity: true
     MaximumCircularVelocitySOFT: true
     MaximumCircularVelocityRadius: true

--- a/property_table.py
+++ b/property_table.py
@@ -336,7 +336,7 @@ class PropertyTable:
             "MostMassiveBlackHolePosition",
             3,
             np.float64,
-            "kpc",
+            "cMpc",
             "Position of most massive black hole.",
             "general",
             "DScale5",

--- a/property_table.py
+++ b/property_table.py
@@ -3178,7 +3178,10 @@ class PropertyTable:
                 parameter_file_properties = self.parameters[base_halo_type][
                     "properties"
                 ]
-                if not parameter_file_properties.get(prop_outputname, True):
+                # Whether to include properties missing from parameter file
+                calculations = self.parameters.get("calculations", {})
+                default = calculations.get("calculate_missing_properties", True)
+                if not parameter_file_properties.get(prop_outputname, default):
                     continue
             except KeyError:
                 pass
@@ -3265,7 +3268,7 @@ class PropertyTable:
             )
         print("}")
 
-    def print_table(self, tablefile: str, footnotefile: str, timestampfile: str, filterfile: str):
+    def print_table(self, tablefile: str, footnotefile: str, timestampfile: str, filterfile: str, variationsfile: str):
         """
         Print the table in .tex format and generate the documentation.
 
@@ -3388,7 +3391,61 @@ Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category & Compression\\\
         with open(filterfile, "w") as ofile:
             for name, value in parameters['filters'].items():
                 ofile.write(f'\\newcommand{{\\{name}filter}}{{{value}}}\n')
+        with open(variationsfile, "w") as ofile:
+            # Determine which ExlusiveSphere and InclusiveSphere apertures are present
+            variations_ES = set()
+            variations_IS = set()
+            apertures = parameters.get('ApertureProperties', {})
+            for _, variation in apertures.get('variations', {}).items():
+                if variation['inclusive']:
+                    variations_IS.add(int(variation['radius_in_kpc']))
+                else:
+                    variations_ES.add(int(variation['radius_in_kpc']))
+            # Write InclusiveSphere aperture list
+            if not variations_IS:
+                ofile.write(f'\\newcommand{{\\variationsIS}}{{-}}\n')
+            else:
+                variations_str = ', '.join(str(ap) for ap in sorted(variations_IS))
+                ofile.write(f'\\newcommand{{\\variationsIS}}{{{variations_str}}}\n')
+            # Write ExclusiveSphere aperture list
+            if not variations_ES:
+                ofile.write(f'\\newcommand{{\\variationsES}}{{-}}\n')
+            else:
+                variations_str = ', '.join(str(ap) for ap in sorted(variations_ES))
+                ofile.write(f'\\newcommand{{\\variationsES}}{{{variations_str}}}\n')
 
+            # Determine which projected apertures are present
+            variations_proj = set()
+            apertures = parameters.get('ProjectedApertureProperties', {})
+            for _, variation in apertures.get('variations', {}).items():
+                variations_proj.add(int(variation['radius_in_kpc']))
+            # Write ProjectedAperture list
+            if not variations_proj:
+                ofile.write(f'\\newcommand{{\\variationsEP}}{{-}}\n')
+            else:
+                variations_str = ', '.join(str(ap) for ap in sorted(variations_proj))
+                ofile.write(f'\\newcommand{{\\variationsEP}}{{{variations_str}}}\n')
+
+            # Determine which SO apertures are present
+            variations_SO = set()
+            apertures = parameters.get('SOProperties', {})
+            for _, variation in apertures.get('variations', {}).items():
+                name = ''
+                if 'radius_multiple' in variation:
+                    name += f'{int(variation["radius_multiple"])}x'
+                if variation['type'] == 'crit':
+                    name += f'{int(variation["value"])}c'
+                elif variation['type'] == 'mean':
+                    name += f'{int(variation["value"])}m'
+                elif variation['type'] == 'BN98':
+                    name += f'BN98'
+                variations_SO.add(name)
+            # Write SOProperties apertures list
+            if not variations_SO:
+                ofile.write(f'\\newcommand{{\\variationsSO}}{{-}}\n')
+            else:
+                variations_str = ', '.join(variations_SO)
+                ofile.write(f'\\newcommand{{\\variationsSO}}{{{variations_str}}}\n')
 
 class DummyProperties:
     """
@@ -3456,4 +3513,5 @@ if __name__ == "__main__":
         "documentation/footnotes.tex",
         "documentation/timestamp.tex",
         "documentation/filters.tex",
+        "documentation/variations.tex",
     )

--- a/property_table.py
+++ b/property_table.py
@@ -3289,7 +3289,7 @@ class PropertyTable:
             )
         print("}")
 
-    def print_table(self, tablefile: str, footnotefile: str, timestampfile: str, filterfile: str, variationsfile: str):
+    def print_table(self, tablefile: str, footnotefile: str, timestampfile: str, filterfile: str):
         """
         Print the table in .tex format and generate the documentation.
 
@@ -3412,61 +3412,7 @@ Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category & Compression\\\
         with open(filterfile, "w") as ofile:
             for name, value in parameters['filters'].items():
                 ofile.write(f'\\newcommand{{\\{name}filter}}{{{value}}}\n')
-        with open(variationsfile, "w") as ofile:
-            # Determine which ExlusiveSphere and InclusiveSphere apertures are present
-            variations_ES = set()
-            variations_IS = set()
-            apertures = parameters.get('ApertureProperties', {})
-            for _, variation in apertures.get('variations', {}).items():
-                if variation['inclusive']:
-                    variations_IS.add(int(variation['radius_in_kpc']))
-                else:
-                    variations_ES.add(int(variation['radius_in_kpc']))
-            # Write InclusiveSphere aperture list
-            if not variations_IS:
-                ofile.write(f'\\newcommand{{\\variationsIS}}{{-}}\n')
-            else:
-                variations_str = ', '.join(str(ap) for ap in sorted(variations_IS))
-                ofile.write(f'\\newcommand{{\\variationsIS}}{{{variations_str}}}\n')
-            # Write ExclusiveSphere aperture list
-            if not variations_ES:
-                ofile.write(f'\\newcommand{{\\variationsES}}{{-}}\n')
-            else:
-                variations_str = ', '.join(str(ap) for ap in sorted(variations_ES))
-                ofile.write(f'\\newcommand{{\\variationsES}}{{{variations_str}}}\n')
 
-            # Determine which projected apertures are present
-            variations_proj = set()
-            apertures = parameters.get('ProjectedApertureProperties', {})
-            for _, variation in apertures.get('variations', {}).items():
-                variations_proj.add(int(variation['radius_in_kpc']))
-            # Write ProjectedAperture list
-            if not variations_proj:
-                ofile.write(f'\\newcommand{{\\variationsEP}}{{-}}\n')
-            else:
-                variations_str = ', '.join(str(ap) for ap in sorted(variations_proj))
-                ofile.write(f'\\newcommand{{\\variationsEP}}{{{variations_str}}}\n')
-
-            # Determine which SO apertures are present
-            variations_SO = set()
-            apertures = parameters.get('SOProperties', {})
-            for _, variation in apertures.get('variations', {}).items():
-                name = ''
-                if 'radius_multiple' in variation:
-                    name += f'{int(variation["radius_multiple"])}x'
-                if variation['type'] == 'crit':
-                    name += f'{int(variation["value"])}c'
-                elif variation['type'] == 'mean':
-                    name += f'{int(variation["value"])}m'
-                elif variation['type'] == 'BN98':
-                    name += f'BN98'
-                variations_SO.add(name)
-            # Write SOProperties apertures list
-            if not variations_SO:
-                ofile.write(f'\\newcommand{{\\variationsSO}}{{-}}\n')
-            else:
-                variations_str = ', '.join(variations_SO)
-                ofile.write(f'\\newcommand{{\\variationsSO}}{{{variations_str}}}\n')
 
 class DummyProperties:
     """
@@ -3535,5 +3481,4 @@ if __name__ == "__main__":
         "documentation/footnotes.tex",
         "documentation/timestamp.tex",
         "documentation/filters.tex",
-        "documentation/variations.tex",
     )


### PR DESCRIPTION
For a subset of the Flamingo10k we don't want to save all properties. This PR adds a parameter file that will only calculate and save the subset we want.

Other changes
- In the current version of SOAP all properties missing from the parameter file were being computed. I've added a flag to determine whether missing properties should be computed, since this makes the new parameter file significantly easier to read.
- Log any properties listed in the parameter file which aren't present in the property table
- ~When generating the pdf documentation the apertures being calculated are now read from the parameter file~ (Reverted since in https://github.com/SWIFTSIM/SOAP/pull/81 I've added a new table to the documentation which lists the variations)
- Reduce gzip compression level
- Use the softened vmax radius when calculating the spin parameter, rather than the unsoftened one