### PR TITLE
Fix crash when we have more MPI ranks than unique bound particle IDs

### DIFF
--- a/read_hbtplus.py
+++ b/read_hbtplus.py
@@ -108,7 +108,7 @@ def read_hbtplus_groupnr(basename):
     unique_ids_bound, unique_counts = psort.parallel_unique(
         ids_bound, comm=comm, arr_sorted=False, return_counts=True
     )
-    assert np.max(unique_counts) == 1
+    assert len(unique_counts)==0 or np.max(unique_counts) == 1
 
     return total_nr_halos, ids_bound, grnr_bound, rank_bound
 


### PR DESCRIPTION
When we count how many instances we have of each bound particle ID in the group membership code, the result is distributed over all MPI ranks so some ranks can have zero elements. We need to avoid calling max() on an empty array in this case.