### PR TITLE
Fix unit attribute name in SOAP output

### DIFF
--- a/group_membership.py
+++ b/group_membership.py
@@ -202,7 +202,7 @@ if __name__ == "__main__":
         # Set up dataset attributes
         unit_attrs = {
             "Conversion factor to CGS (not including cosmological corrections)": [1.0],
-            "Conversion factor to CGS (including cosmological corrections)": [1.0],
+            "Conversion factor to physical CGS (including cosmological corrections)": [1.0],
             "U_I exponent": [0.0],
             "U_L exponent": [0.0],
             "U_M exponent": [0.0],

--- a/swift_units.py
+++ b/swift_units.py
@@ -172,7 +172,7 @@ def attributes_from_units(units):
     attrs["Conversion factor to CGS (not including cosmological corrections)"] = [
         float(cgs_factor / (a_val ** a_exponent) / (h_val ** h_exponent))
     ]
-    attrs["Conversion factor to CGS (including cosmological corrections)"] = [
+    attrs["Conversion factor to physical CGS (including cosmological corrections)"] = [
         float(cgs_factor)
     ]
     attrs["U_I exponent"] = [float(powers[unyt.dimensions.current_mks])]


### PR DESCRIPTION
This changes the physical conversion factor attribute on output arrays for consistency with Swift.