### PR TITLE
Rearrange group_membership.py to minimize peak memory use

### DIFF
--- a/group_membership.py
+++ b/group_membership.py
@@ -239,6 +239,7 @@ if __name__ == "__main__":
 
     # Read in FOF file information if a separate file has been passed
     fof_ptypes = []
+    fof_file = None
     if fof_filename != '':
         # Determine particle types which exist in the FOF file
         if comm_rank == 0:

--- a/group_membership.py
+++ b/group_membership.py
@@ -95,7 +95,7 @@ def process_particle_type(ptype, snap_file, ids_bound, grnr_bound, rank_bound,
     # Set up dataset attributes
     unit_attrs = {
         "Conversion factor to CGS (not including cosmological corrections)": [1.0],
-        "Conversion factor to CGS (including cosmological corrections)": [1.0],
+        "Conversion factor to physical CGS (including cosmological corrections)": [1.0],
         "U_I exponent": [0.0],
         "U_L exponent": [0.0],
         "U_M exponent": [0.0],

--- a/group_membership.py
+++ b/group_membership.py
@@ -13,12 +13,135 @@ import read_vr
 import read_hbtplus
 import read_subfind
 import read_rockstar
-
 from mpi4py import MPI
 
 comm = MPI.COMM_WORLD
 comm_rank = comm.Get_rank()
 comm_size = comm.Get_size()
+
+
+def process_particle_type(ptype, snap_file, ids_bound, grnr_bound, rank_bound,
+                          ids_unbound, fof_ptypes, fof_file, create_file):
+    """
+    Compute group membership for one particle type
+    """
+    if comm_rank == 0:
+        print("Calculating group membership for type", ptype)
+    swift_ids = snap_file.read(("ParticleIDs",), ptype)["ParticleIDs"]
+
+    # Report memory load
+    nr_parts_local = len(swift_ids)
+    max_nr_parts_local = comm.allreduce(nr_parts_local, op=MPI.MAX)
+    min_nr_parts_local = comm.allreduce(nr_parts_local, op=MPI.MIN)
+    if comm_rank == 0:
+        print(f"  Number of snapshot particle IDs per rank min={min_nr_parts_local}, max={max_nr_parts_local}")
+
+    # Look up FoF group membership of the particles
+    if ptype in fof_ptypes:
+        if comm_rank == 0:
+            print("  Matching FOF catalogue to snapshot")
+        fof_particle_ids = fof_file.read(("ParticleIDs",), ptype)["ParticleIDs"]
+        fof_group_ids = fof_file.read(("FOFGroupIDs",), ptype)["FOFGroupIDs"]
+        ptr = psort.parallel_match(swift_ids, fof_particle_ids)
+        del fof_particle_ids
+        swift_fof_group_ids = psort.fetch_elements(fof_group_ids, ptr)
+        del fof_group_ids
+        del ptr
+
+    if comm_rank == 0:
+        print("  Matching SWIFT particle IDs to bound IDs")
+    ptr = psort.parallel_match(swift_ids, ids_bound)
+
+    if comm_rank == 0:
+        print("  Assigning bound group membership to SWIFT particles")
+    matched = ptr >= 0
+    swift_grnr_bound = np.ndarray(len(swift_ids), dtype=grnr_bound.dtype)
+    swift_grnr_bound[matched] = psort.fetch_elements(grnr_bound, ptr[matched])
+    swift_grnr_bound[matched == False] = -1
+
+    if rank_bound is not None:
+        if comm_rank == 0:
+            print("  Assigning rank by binding energy to SWIFT particles")
+        swift_rank_bound = np.ndarray(len(swift_ids), dtype=rank_bound.dtype)
+        swift_rank_bound[matched] = psort.fetch_elements(rank_bound, ptr[matched])
+        swift_rank_bound[matched == False] = -1
+    del ptr
+    del matched
+        
+    if ids_unbound is not None:
+        if comm_rank == 0:
+            print("  Matching SWIFT particle IDs to unbound IDs")
+        ptr = psort.parallel_match(swift_ids, ids_unbound)
+
+        if comm_rank == 0:
+            print("  Assigning unbound group membership to SWIFT particles")
+        matched = ptr >= 0
+        swift_grnr_unbound = np.ndarray(len(swift_ids), dtype=grnr_unbound.dtype)
+        swift_grnr_unbound[matched] = psort.fetch_elements(
+            grnr_unbound, ptr[matched]
+        )
+        swift_grnr_unbound[matched == False] = -1
+        swift_grnr_all = np.maximum(swift_grnr_bound, swift_grnr_unbound)
+        del ptr
+        del matched
+        
+    # Determine if we need to create a new output file set
+    if create_file:
+        mode = "w"
+        create_file = False
+    else:
+        mode = "r+"
+
+    # Set up dataset attributes
+    unit_attrs = {
+        "Conversion factor to CGS (not including cosmological corrections)": [1.0],
+        "Conversion factor to CGS (including cosmological corrections)": [1.0],
+        "U_I exponent": [0.0],
+        "U_L exponent": [0.0],
+        "U_M exponent": [0.0],
+        "U_t exponent": [0.0],
+        "U_T exponent": [0.0],
+        "a-scale exponent": [0.0],
+        "h-scale exponent": [0.0],
+    }
+    attrs = {
+        "GroupNr_bound": {
+            "Description": "Index of halo in which this particle is a bound member, or -1 if none"
+        },
+        "Rank_bound": {
+            "Description": "Ranking by binding energy of the bound particles (first in halo=0), or -1 if not bound"
+        },
+        "GroupNr_all": {
+            "Description": "Index of halo in which this particle is a member (bound or unbound), or -1 if none"
+        },
+        "FOFGroupIDs": {
+            "Description": "Friends-Of-Friends ID of the group in which this particle is a member, of -1 if none"
+        },
+    }
+    attrs["GroupNr_bound"].update(unit_attrs)
+    attrs["Rank_bound"].update(unit_attrs)
+    attrs["GroupNr_all"].update(unit_attrs)
+    attrs["FOFGroupIDs"].update(unit_attrs)
+
+    # Write these particles out with the same layout as the input snapshot
+    if comm_rank == 0:
+        print("  Writing out group membership of SWIFT particles")
+    elements_per_file = snap_file.get_elements_per_file("ParticleIDs", group=ptype)
+    output = {"GroupNr_bound": swift_grnr_bound}
+    if rank_bound is not None:
+        output["Rank_bound"] = swift_rank_bound
+    if ids_unbound is not None:
+        output["GroupNr_all"] = swift_grnr_all
+    if ptype in fof_ptypes:
+        output["FOFGroupIDs"] = swift_fof_group_ids
+    snap_file.write(
+        output,
+        elements_per_file,
+        filenames=output_file,
+        mode=mode,
+        group=ptype,
+        attrs=attrs,
+    )
 
 
 if __name__ == "__main__":
@@ -134,121 +257,9 @@ if __name__ == "__main__":
     # Loop over particle types
     create_file = True
     for ptype in ptypes:
-
-        if comm_rank == 0:
-            print("Calculating group membership for type", ptype)
-        swift_ids = snap_file.read(("ParticleIDs",), ptype)["ParticleIDs"]
-
-        # Report memory load
-        nr_parts_local = len(swift_ids)
-        max_nr_parts_local = comm.allreduce(nr_parts_local, op=MPI.MAX)
-        min_nr_parts_local = comm.allreduce(nr_parts_local, op=MPI.MIN)
-        if comm_rank == 0:
-            print(f"  Number of snapshot particle IDs per rank min={min_nr_parts_local}, max={max_nr_parts_local}")
-        
-        # Allocate array to store SWIFT particle group membership
-        swift_grnr_bound = np.ndarray(len(swift_ids), dtype=grnr_bound.dtype)
-        if rank_bound is not None:
-            swift_rank_bound = np.ndarray(len(swift_ids), dtype=rank_bound.dtype)
-        if ids_unbound is not None:
-            swift_grnr_unbound = np.ndarray(len(swift_ids), dtype=grnr_unbound.dtype)
-
-        if comm_rank == 0:
-            print("  Matching SWIFT particle IDs to bound IDs")
-        ptr = psort.parallel_match(swift_ids, ids_bound)
-
-        if comm_rank == 0:
-            print("  Assigning bound group membership to SWIFT particles")
-        matched = ptr >= 0
-        swift_grnr_bound[matched] = psort.fetch_elements(grnr_bound, ptr[matched])
-        swift_grnr_bound[matched == False] = -1
-
-        if rank_bound is not None:
-            if comm_rank == 0:
-                print("  Assigning rank by binding energy to SWIFT particles")
-            swift_rank_bound[matched] = psort.fetch_elements(rank_bound, ptr[matched])
-            swift_rank_bound[matched == False] = -1
-
-        if ids_unbound is not None:
-            if comm_rank == 0:
-                print("  Matching SWIFT particle IDs to unbound IDs")
-            ptr = psort.parallel_match(swift_ids, ids_unbound)
-
-            if comm_rank == 0:
-                print("  Assigning unbound group membership to SWIFT particles")
-            matched = ptr >= 0
-            swift_grnr_unbound[matched] = psort.fetch_elements(
-                grnr_unbound, ptr[matched]
-            )
-            swift_grnr_unbound[matched == False] = -1
-            swift_grnr_all = np.maximum(swift_grnr_bound, swift_grnr_unbound)
-
-        if ptype in fof_ptypes:
-            if comm_rank == 0:
-                print("  Matching FOF catalogue to snapshot")
-            fof_particle_ids = fof_file.read(("ParticleIDs",), ptype)["ParticleIDs"]
-            fof_group_ids = fof_file.read(("FOFGroupIDs",), ptype)["FOFGroupIDs"]
-            ptr = psort.parallel_match(swift_ids, fof_particle_ids)
-            swift_fof_group_ids = np.ndarray(len(swift_ids), dtype=fof_group_ids.dtype)
-            swift_fof_group_ids = psort.fetch_elements(fof_group_ids, ptr)
-
-        # Determine if we need to create a new output file set
-        if create_file:
-            mode = "w"
-            create_file = False
-        else:
-            mode = "r+"
-
-        # Set up dataset attributes
-        unit_attrs = {
-            "Conversion factor to CGS (not including cosmological corrections)": [1.0],
-            "Conversion factor to CGS (including cosmological corrections)": [1.0],
-            "U_I exponent": [0.0],
-            "U_L exponent": [0.0],
-            "U_M exponent": [0.0],
-            "U_t exponent": [0.0],
-            "U_T exponent": [0.0],
-            "a-scale exponent": [0.0],
-            "h-scale exponent": [0.0],
-        }
-        attrs = {
-            "GroupNr_bound": {
-                "Description": "Index of halo in which this particle is a bound member, or -1 if none"
-            },
-            "Rank_bound": {
-                "Description": "Ranking by binding energy of the bound particles (first in halo=0), or -1 if not bound"
-            },
-            "GroupNr_all": {
-                "Description": "Index of halo in which this particle is a member (bound or unbound), or -1 if none"
-            },
-            "FOFGroupIDs": {
-                "Description": "Friends-Of-Friends ID of the group in which this particle is a member, of -1 if none"
-            },
-        }
-        attrs["GroupNr_bound"].update(unit_attrs)
-        attrs["Rank_bound"].update(unit_attrs)
-        attrs["GroupNr_all"].update(unit_attrs)
-        attrs["FOFGroupIDs"].update(unit_attrs)
-
-        # Write these particles out with the same layout as the input snapshot
-        if comm_rank == 0:
-            print("  Writing out group membership of SWIFT particles")
-        elements_per_file = snap_file.get_elements_per_file("ParticleIDs", group=ptype)
-        output = {"GroupNr_bound": swift_grnr_bound}
-        if rank_bound is not None:
-            output["Rank_bound"] = swift_rank_bound
-        if ids_unbound is not None:
-            output["GroupNr_all"] = swift_grnr_all
-        if ptype in fof_ptypes:
-            output["FOFGroupIDs"] = swift_fof_group_ids
-        snap_file.write(
-            output,
-            elements_per_file,
-            filenames=output_file,
-            mode=mode,
-            group=ptype,
-            attrs=attrs,
-        )
+        process_particle_type(ptype, snap_file, ids_bound, grnr_bound, rank_bound,
+                              ids_unbound, fof_ptypes, fof_file, create_file)
+        create_file = False
 
     comm.barrier()
     if comm_rank == 0:


### PR DESCRIPTION
This moves the code that computes group membership for one particle type into a function so that any variables which don't need to be preserved go out of scope between iterations. I've changed it to compute FOF membership first because I think that will cause a bigger spike in memory use than matching up just the bound particles so we should do it before allocating the other arrays. I also added a few del statements to try to free temporary arrays as soon as possible.

This version now runs on a FLAMINGO L1000N1800/HYDRO snapshot in <10 minutes on one cosma8 node. Master had problems with getting very slow on the new cosma-8 when free memory was low (although "available" memory in top was not low, so it's not clear exactly what the problem is).