### PR TITLE
Update gas filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 __pycache__
 *~
 logs
-openmpi-5.0.3-hdf5-1.12.3-env/
+openmpi-5.0.3-hdf5-1.12.3-env
 
 documentation/SOAP.aux
 documentation/SOAP.log

--- a/cold_dense_gas_filter.py
+++ b/cold_dense_gas_filter.py
@@ -25,15 +25,11 @@ class ColdDenseGasFilter:
     "cold and dense".
     """
 
-    # maximum temperature to be considered cold
-    maximum_temperature: unyt.unyt_quantity
-    # minimum hydrogen number density to be considered dense
-    minimum_hydrogen_number_density: unyt.unyt_quantity
-
     def __init__(
         self,
-        maximum_temperature: unyt.unyt_quantity = 10.0 ** 4.5 * unyt.K,
-        minimum_hydrogen_number_density: unyt.unyt_quantity = 0.1 / unyt.cm ** 3,
+        maximum_temperature: unyt.unyt_quantity,
+        minimum_hydrogen_number_density: unyt.unyt_quantity,
+        initialised: bool,
     ):
         """
         Construct the filter.
@@ -44,9 +40,13 @@ class ColdDenseGasFilter:
          - minimum_hydrogen_number_density: unyt.unyt_quantity
            Minimum hydrogen number density above which gas is considered to
            be dense.
+         - initialised: bool
+           If the parameters required for the filter where found in the parameter
+           file. If this is false and the filter is called, it will throw an error.
         """
         self.maximum_temperature = maximum_temperature
         self.minimum_hydrogen_number_density = minimum_hydrogen_number_density
+        self.initialised = initialised
 
     def is_cold_and_dense(
         self, temperature: unyt.unyt_array, mass_density: unyt.unyt_array
@@ -62,6 +62,8 @@ class ColdDenseGasFilter:
 
         Returns a mask array that can be used to index other particle arrays.
         """
+        if not self.initialised:
+            raise RuntimeError('ColdDenseGasFilter was not initialised')
         hydrogen_number_density = mass_density / unyt.mh
         return (temperature < self.maximum_temperature.to(temperature.units)) & (
             hydrogen_number_density

--- a/combine_chunks.py
+++ b/combine_chunks.py
@@ -229,7 +229,7 @@ def combine_chunks(
                 # Remove property name from full hdf5 path
                 group_name = '/'.join(metadata[0].split('/')[:-1])
                 subhalo_types.add(group_name)
-            header.attrs['SubhaloTypes'] = list(subhalo_types)
+            header.attrs['SubhaloTypes'] = sorted(subhalo_types)
 
             # Save masks for each halo variation
             for halo_prop in halo_prop_list:

--- a/combine_chunks.py
+++ b/combine_chunks.py
@@ -199,7 +199,7 @@ def combine_chunks(
             cells_metadata = cells.create_group("Meta-data")
             cells_metadata.attrs['dimension'] = cellgrid.dimension
             cells_metadata.attrs['nr_cells'] = cellgrid.nr_cells
-            cell_size = cellgrid.cell_size.to('snap_length').value
+            cell_size = cellgrid.cell_size.to('a*snap_length').value
             cells_metadata.attrs['size'] = cell_size
             cells.create_dataset('Centres', data=cellgrid.cell_centres)
             cells.create_dataset('Counts/Subhalos', data=cell_counts)

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -140,16 +140,36 @@ def compute_halo_properties():
         parameter_file.get_defined_constants()
     )
 
+    recently_heated_params = args.calculations["recently_heated_gas_filter"]
+    if (not args.dmo) and (recently_heated_params['use_AGN_delta_T']):
+        assert cellgrid.AGN_delta_T.value != 0, "Invalid value for AGN_delta_T"
     recently_heated_gas_filter = RecentlyHeatedGasFilter(
         cellgrid,
-        delta_time=15.0 * unyt.Myr,
+        recently_heated_params['delta_time_myr']*unyt.Myr,
+        recently_heated_params['use_AGN_delta_T'],
         delta_logT_min=-1.0,
         delta_logT_max=0.3,
-        AGN_delta_T=8.80144197177e7 * unyt.K,
     )
 
     stellar_age_calculator = StellarAgeCalculator(cellgrid)
-    cold_dense_gas_filter = ColdDenseGasFilter(10.0 ** 4.5 * unyt.K, 0.1 / unyt.cm ** 3)
+
+    # Try to load parameters for ColdDenseGasFilter. If a property that uses the
+    # filter is calculated when the parameters could not be found, the code will
+    # crash.
+    try:
+        cold_dense_params = args.calculations["cold_dense_gas_filter"]
+        cold_dense_gas_filter = ColdDenseGasFilter(
+            cold_dense_params['maximum_temperature_K'] * unyt.K,
+            cold_dense_params['minimum_hydrogen_number_density_cm3'] / unyt.cm ** 3,
+            True,
+        )
+    except KeyError:
+        cold_dense_gas_filter = ColdDenseGasFilter(
+            0 * unyt.K,
+            0 / unyt.cm ** 3,
+            False,
+        )
+
     default_filters = {
         'general': {
                 'limit': 100,

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -145,8 +145,8 @@ def compute_halo_properties():
         assert cellgrid.AGN_delta_T.value != 0, "Invalid value for AGN_delta_T"
     recently_heated_gas_filter = RecentlyHeatedGasFilter(
         cellgrid,
-        recently_heated_params['delta_time_myr']*unyt.Myr,
-        recently_heated_params['use_AGN_delta_T'],
+        float(recently_heated_params['delta_time_myr']) * unyt.Myr,
+        float(recently_heated_params['use_AGN_delta_T']),
         delta_logT_min=-1.0,
         delta_logT_max=0.3,
     )
@@ -159,8 +159,8 @@ def compute_halo_properties():
     try:
         cold_dense_params = args.calculations["cold_dense_gas_filter"]
         cold_dense_gas_filter = ColdDenseGasFilter(
-            cold_dense_params['maximum_temperature_K'] * unyt.K,
-            cold_dense_params['minimum_hydrogen_number_density_cm3'] / unyt.cm ** 3,
+            float(cold_dense_params['maximum_temperature_K']) * unyt.K,
+            float(cold_dense_params['minimum_hydrogen_number_density_cm3']) / unyt.cm ** 3,
             True,
         )
     except KeyError:

--- a/documentation/SOAP.tex
+++ b/documentation/SOAP.tex
@@ -75,9 +75,9 @@ to SOAP. These are stored in a separate group, \verb+InputHalos+.
 present in the catalogue.
 These are stored in a separate group, \verb+SOAP+. This is just done for convenience; these quantities can be computed from the SOAP output alone.
 
-\paragraph{The table below lists} the halo variations present in this run of SOAP.
+\paragraph{The table below lists} all the groups in the output file which containing datasets.
 Note that there will be three groups (\verb+x+, \verb+y+ or \verb+z+) for each \verb+ProjectedAperture+ variation.
-Each variation can have a filter applied to it. If a halo does not satisfy the filter then the variation will
+Each halo variation can have a filter applied to it. If a halo does not satisfy the filter then the variation will
 not be calculated for that halo. More information on filters can be found in the next section.
 
 \input{variations_table}

--- a/group_membership.py
+++ b/group_membership.py
@@ -13,12 +13,135 @@ import read_vr
 import read_hbtplus
 import read_subfind
 import read_rockstar
-
 from mpi4py import MPI
 
 comm = MPI.COMM_WORLD
 comm_rank = comm.Get_rank()
 comm_size = comm.Get_size()
+
+
+def process_particle_type(ptype, snap_file, ids_bound, grnr_bound, rank_bound,
+                          ids_unbound, fof_ptypes, fof_file, create_file):
+    """
+    Compute group membership for one particle type
+    """
+    if comm_rank == 0:
+        print("Calculating group membership for type", ptype)
+    swift_ids = snap_file.read(("ParticleIDs",), ptype)["ParticleIDs"]
+
+    # Report memory load
+    nr_parts_local = len(swift_ids)
+    max_nr_parts_local = comm.allreduce(nr_parts_local, op=MPI.MAX)
+    min_nr_parts_local = comm.allreduce(nr_parts_local, op=MPI.MIN)
+    if comm_rank == 0:
+        print(f"  Number of snapshot particle IDs per rank min={min_nr_parts_local}, max={max_nr_parts_local}")
+
+    # Look up FoF group membership of the particles
+    if ptype in fof_ptypes:
+        if comm_rank == 0:
+            print("  Matching FOF catalogue to snapshot")
+        fof_particle_ids = fof_file.read(("ParticleIDs",), ptype)["ParticleIDs"]
+        fof_group_ids = fof_file.read(("FOFGroupIDs",), ptype)["FOFGroupIDs"]
+        ptr = psort.parallel_match(swift_ids, fof_particle_ids)
+        del fof_particle_ids
+        swift_fof_group_ids = psort.fetch_elements(fof_group_ids, ptr)
+        del fof_group_ids
+        del ptr
+
+    if comm_rank == 0:
+        print("  Matching SWIFT particle IDs to bound IDs")
+    ptr = psort.parallel_match(swift_ids, ids_bound)
+
+    if comm_rank == 0:
+        print("  Assigning bound group membership to SWIFT particles")
+    matched = ptr >= 0
+    swift_grnr_bound = np.ndarray(len(swift_ids), dtype=grnr_bound.dtype)
+    swift_grnr_bound[matched] = psort.fetch_elements(grnr_bound, ptr[matched])
+    swift_grnr_bound[matched == False] = -1
+
+    if rank_bound is not None:
+        if comm_rank == 0:
+            print("  Assigning rank by binding energy to SWIFT particles")
+        swift_rank_bound = np.ndarray(len(swift_ids), dtype=rank_bound.dtype)
+        swift_rank_bound[matched] = psort.fetch_elements(rank_bound, ptr[matched])
+        swift_rank_bound[matched == False] = -1
+    del ptr
+    del matched
+
+    if ids_unbound is not None:
+        if comm_rank == 0:
+            print("  Matching SWIFT particle IDs to unbound IDs")
+        ptr = psort.parallel_match(swift_ids, ids_unbound)
+
+        if comm_rank == 0:
+            print("  Assigning unbound group membership to SWIFT particles")
+        matched = ptr >= 0
+        swift_grnr_unbound = np.ndarray(len(swift_ids), dtype=grnr_unbound.dtype)
+        swift_grnr_unbound[matched] = psort.fetch_elements(
+            grnr_unbound, ptr[matched]
+        )
+        swift_grnr_unbound[matched == False] = -1
+        swift_grnr_all = np.maximum(swift_grnr_bound, swift_grnr_unbound)
+        del ptr
+        del matched
+
+    # Determine if we need to create a new output file set
+    if create_file:
+        mode = "w"
+        create_file = False
+    else:
+        mode = "r+"
+
+    # Set up dataset attributes
+    unit_attrs = {
+        "Conversion factor to CGS (not including cosmological corrections)": [1.0],
+        "Conversion factor to physical CGS (including cosmological corrections)": [1.0],
+        "U_I exponent": [0.0],
+        "U_L exponent": [0.0],
+        "U_M exponent": [0.0],
+        "U_t exponent": [0.0],
+        "U_T exponent": [0.0],
+        "a-scale exponent": [0.0],
+        "h-scale exponent": [0.0],
+    }
+    attrs = {
+        "GroupNr_bound": {
+            "Description": "Index of halo in which this particle is a bound member, or -1 if none"
+        },
+        "Rank_bound": {
+            "Description": "Ranking by binding energy of the bound particles (first in halo=0), or -1 if not bound"
+        },
+        "GroupNr_all": {
+            "Description": "Index of halo in which this particle is a member (bound or unbound), or -1 if none"
+        },
+        "FOFGroupIDs": {
+            "Description": "Friends-Of-Friends ID of the group in which this particle is a member, of -1 if none"
+        },
+    }
+    attrs["GroupNr_bound"].update(unit_attrs)
+    attrs["Rank_bound"].update(unit_attrs)
+    attrs["GroupNr_all"].update(unit_attrs)
+    attrs["FOFGroupIDs"].update(unit_attrs)
+
+    # Write these particles out with the same layout as the input snapshot
+    if comm_rank == 0:
+        print("  Writing out group membership of SWIFT particles")
+    elements_per_file = snap_file.get_elements_per_file("ParticleIDs", group=ptype)
+    output = {"GroupNr_bound": swift_grnr_bound}
+    if rank_bound is not None:
+        output["Rank_bound"] = swift_rank_bound
+    if ids_unbound is not None:
+        output["GroupNr_all"] = swift_grnr_all
+    if ptype in fof_ptypes:
+        output["FOFGroupIDs"] = swift_fof_group_ids
+    snap_file.write(
+        output,
+        elements_per_file,
+        filenames=output_file,
+        mode=mode,
+        group=ptype,
+        attrs=attrs,
+    )
 
 
 if __name__ == "__main__":
@@ -39,7 +162,7 @@ if __name__ == "__main__":
     halo_format = args["HaloFinder"]["type"]
     halo_basename = args["HaloFinder"]["filename"]
     output_file = args["GroupMembership"]["filename"]
-    
+
     # Substitute in the snapshot number where necessary
     pf = PartialFormatter()
     swift_filename = pf.format(swift_filename, snap_nr=snap_nr, file_nr=None)
@@ -52,7 +175,7 @@ if __name__ == "__main__":
         assert 'file_nr' in output_file, "Membership filenames require {file_nr}"
     else:
         assert 'file_nr' not in output_file, "Membership filenames shouldn't have {file_nr}"
-    
+
     # Ensure output dir exists
     if comm_rank == 0:
         lustre.ensure_output_dir(output_file)
@@ -122,6 +245,7 @@ if __name__ == "__main__":
 
     # Read in FOF file information if a separate file has been passed
     fof_ptypes = []
+    fof_file = None
     if fof_filename != '':
         # Determine particle types which exist in the FOF file
         if comm_rank == 0:
@@ -140,121 +264,9 @@ if __name__ == "__main__":
     # Loop over particle types
     create_file = True
     for ptype in ptypes:
-
-        if comm_rank == 0:
-            print("Calculating group membership for type", ptype)
-        swift_ids = snap_file.read(("ParticleIDs",), ptype)["ParticleIDs"]
-
-        # Report memory load
-        nr_parts_local = len(swift_ids)
-        max_nr_parts_local = comm.allreduce(nr_parts_local, op=MPI.MAX)
-        min_nr_parts_local = comm.allreduce(nr_parts_local, op=MPI.MIN)
-        if comm_rank == 0:
-            print(f"  Number of snapshot particle IDs per rank min={min_nr_parts_local}, max={max_nr_parts_local}")
-        
-        # Allocate array to store SWIFT particle group membership
-        swift_grnr_bound = np.ndarray(len(swift_ids), dtype=grnr_bound.dtype)
-        if rank_bound is not None:
-            swift_rank_bound = np.ndarray(len(swift_ids), dtype=rank_bound.dtype)
-        if ids_unbound is not None:
-            swift_grnr_unbound = np.ndarray(len(swift_ids), dtype=grnr_unbound.dtype)
-
-        if comm_rank == 0:
-            print("  Matching SWIFT particle IDs to bound IDs")
-        ptr = psort.parallel_match(swift_ids, ids_bound)
-
-        if comm_rank == 0:
-            print("  Assigning bound group membership to SWIFT particles")
-        matched = ptr >= 0
-        swift_grnr_bound[matched] = psort.fetch_elements(grnr_bound, ptr[matched])
-        swift_grnr_bound[matched == False] = -1
-
-        if rank_bound is not None:
-            if comm_rank == 0:
-                print("  Assigning rank by binding energy to SWIFT particles")
-            swift_rank_bound[matched] = psort.fetch_elements(rank_bound, ptr[matched])
-            swift_rank_bound[matched == False] = -1
-
-        if ids_unbound is not None:
-            if comm_rank == 0:
-                print("  Matching SWIFT particle IDs to unbound IDs")
-            ptr = psort.parallel_match(swift_ids, ids_unbound)
-
-            if comm_rank == 0:
-                print("  Assigning unbound group membership to SWIFT particles")
-            matched = ptr >= 0
-            swift_grnr_unbound[matched] = psort.fetch_elements(
-                grnr_unbound, ptr[matched]
-            )
-            swift_grnr_unbound[matched == False] = -1
-            swift_grnr_all = np.maximum(swift_grnr_bound, swift_grnr_unbound)
-
-        if ptype in fof_ptypes:
-            if comm_rank == 0:
-                print("  Matching FOF catalogue to snapshot")
-            fof_particle_ids = fof_file.read(("ParticleIDs",), ptype)["ParticleIDs"]
-            fof_group_ids = fof_file.read(("FOFGroupIDs",), ptype)["FOFGroupIDs"]
-            ptr = psort.parallel_match(swift_ids, fof_particle_ids)
-            swift_fof_group_ids = np.ndarray(len(swift_ids), dtype=fof_group_ids.dtype)
-            swift_fof_group_ids = psort.fetch_elements(fof_group_ids, ptr)
-
-        # Determine if we need to create a new output file set
-        if create_file:
-            mode = "w"
-            create_file = False
-        else:
-            mode = "r+"
-
-        # Set up dataset attributes
-        unit_attrs = {
-            "Conversion factor to CGS (not including cosmological corrections)": [1.0],
-            "Conversion factor to physical CGS (including cosmological corrections)": [1.0],
-            "U_I exponent": [0.0],
-            "U_L exponent": [0.0],
-            "U_M exponent": [0.0],
-            "U_t exponent": [0.0],
-            "U_T exponent": [0.0],
-            "a-scale exponent": [0.0],
-            "h-scale exponent": [0.0],
-        }
-        attrs = {
-            "GroupNr_bound": {
-                "Description": "Index of halo in which this particle is a bound member, or -1 if none"
-            },
-            "Rank_bound": {
-                "Description": "Ranking by binding energy of the bound particles (first in halo=0), or -1 if not bound"
-            },
-            "GroupNr_all": {
-                "Description": "Index of halo in which this particle is a member (bound or unbound), or -1 if none"
-            },
-            "FOFGroupIDs": {
-                "Description": "Friends-Of-Friends ID of the group in which this particle is a member, of -1 if none"
-            },
-        }
-        attrs["GroupNr_bound"].update(unit_attrs)
-        attrs["Rank_bound"].update(unit_attrs)
-        attrs["GroupNr_all"].update(unit_attrs)
-        attrs["FOFGroupIDs"].update(unit_attrs)
-
-        # Write these particles out with the same layout as the input snapshot
-        if comm_rank == 0:
-            print("  Writing out group membership of SWIFT particles")
-        elements_per_file = snap_file.get_elements_per_file("ParticleIDs", group=ptype)
-        output = {"GroupNr_bound": swift_grnr_bound}
-        if rank_bound is not None:
-            output["Rank_bound"] = swift_rank_bound
-        if ids_unbound is not None:
-            output["GroupNr_all"] = swift_grnr_all
-        if ptype in fof_ptypes:
-            output["FOFGroupIDs"] = swift_fof_group_ids
-        snap_file.write(
-            output,
-            elements_per_file,
-            filenames=output_file,
-            mode=mode,
-            group=ptype,
-            attrs=attrs,
-        )
+        process_particle_type(ptype, snap_file, ids_bound, grnr_bound, rank_bound,
+                              ids_unbound, fof_ptypes, fof_file, create_file)
+        create_file = False
 
     comm.barrier()
     if comm_rank == 0:

--- a/parameter_files/COLIBRE.yml
+++ b/parameter_files/COLIBRE.yml
@@ -555,3 +555,9 @@ calculations:
   recalculate_xrays: false
   min_read_radius_cmpc: 0.5
   calculate_missing_properties: true
+  recently_heated_gas_filter:
+    delta_time_myr: 15
+    use_AGN_delta_T: true
+  cold_dense_gas_filter:
+    maximum_temperature_K: 3.16e4
+    minimum_hydrogen_number_density_cm3: 0.1

--- a/parameter_files/COLIBRE.yml
+++ b/parameter_files/COLIBRE.yml
@@ -557,7 +557,7 @@ calculations:
   calculate_missing_properties: true
   recently_heated_gas_filter:
     delta_time_myr: 15
-    use_AGN_delta_T: true
+    use_AGN_delta_T: false
   cold_dense_gas_filter:
     maximum_temperature_K: 3.16e4
     minimum_hydrogen_number_density_cm3: 0.1

--- a/parameter_files/FLAMINGO.yml
+++ b/parameter_files/FLAMINGO.yml
@@ -542,3 +542,6 @@ calculations:
     min_halo_mass: 1e13
     halo_bin_size_dex: .05
     halos_per_bin: 200
+  recently_heated_gas_filter:
+    delta_time_myr: 15
+    use_AGN_delta_T: true

--- a/property_table.py
+++ b/property_table.py
@@ -4042,10 +4042,10 @@ Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category & Compression\\\
 
         # Create table of variations of each halo type, always add BoundSubhalo
         tablestr = """\\pagebreak
-\\begin{adjustbox}{tabular=lllcl,center}
-& Name (HDF5) & Name (swiftsimio) & Inclusive? & Filter \\\\
-\\hline{}
-SH & \\verb+BoundSubhalo+ & \\verb+bound_subhalo+ & \\ding{53} & - \\\\*\n"""
+\\begin{adjustbox}{tabular=llcl,center}
+Group name (HDF5) & Group name (swiftsimio) & Inclusive? & Filter \\\\
+\\hline
+\\verb+BoundSubhalo+ & \\verb+bound_subhalo+ & \\ding{53} & - \\\\*\n"""
         # Add SO apertures to table
         apertures = parameters.get('SOProperties', {})
         for _, variation in apertures.get('variations', {}).items():
@@ -4058,7 +4058,7 @@ SH & \\verb+BoundSubhalo+ & \\verb+bound_subhalo+ & \\ding{53} & - \\\\*\n"""
                 name += f'{variation["value"]:.0f}_{variation["type"]}'
             filter = variation.get('filter', 'basic')
             filter = '-' if filter == 'basic' else filter
-            tablestr += f'SO & \\verb+SO/{name}+ & \\verb+spherical_overdensity_{name.lower()}+& \\ding{{51}} & {filter} \\\\*\n'
+            tablestr += f'\\verb+SO/{name}+ & \\verb+spherical_overdensity_{name.lower()}+& \\ding{{51}} & {filter} \\\\*\n'
         # Determine which ExclusiveSphere and InclusiveSphere apertures are present
         variations_ES, variations_IS = {}, {}
         apertures = parameters.get('ApertureProperties', {})
@@ -4070,11 +4070,11 @@ SH & \\verb+BoundSubhalo+ & \\verb+bound_subhalo+ & \\ding{53} & - \\\\*\n"""
         # Add ExclusiveSphere apertures to table in sorted order
         for radius in sorted(variations_ES.keys()):
             filter = '-' if variations_ES[radius] == 'basic' else variations_ES[radius]
-            tablestr += f'ES & \\verb+ExclusiveSphere/{radius}kpc+ & \\verb+exclusive_sphere_{radius}kpc+ & \\ding{{53}} & {filter} \\\\*\n'
+            tablestr += f'\\verb+ExclusiveSphere/{radius}kpc+ & \\verb+exclusive_sphere_{radius}kpc+ & \\ding{{53}} & {filter} \\\\*\n'
         # Add InclusiveSphere apertures to table in sorted order
         for radius in sorted(variations_IS.keys()):
             filter = '-' if variations_IS[radius] == 'basic' else variations_IS[radius]
-            tablestr += f'IS & \\verb+InclusiveSphere/{radius}kpc+ & \\verb+inclusive_sphere_{radius}kpc+ & \\ding{{51}} & {filter} \\\\*\n'
+            tablestr += f'\\verb+InclusiveSphere/{radius}kpc+ & \\verb+inclusive_sphere_{radius}kpc+ & \\ding{{51}} & {filter} \\\\*\n'
         # Determine which projected apertures are present
         variations_proj = {}
         apertures = parameters.get('ProjectedApertureProperties', {})
@@ -4083,7 +4083,14 @@ SH & \\verb+BoundSubhalo+ & \\verb+bound_subhalo+ & \\ding{53} & - \\\\*\n"""
         # Add ProjectedApertures to table in sorted order
         for radius in sorted(variations_proj.keys()):
             filter = '-' if variations_proj[radius] == 'basic' else variations_proj[radius]
-            tablestr += f'EP & \\verb+ProjectedAperture/{radius}kpc/projP+ & \\verb+projected_aperture_{radius}kpc_projP+ & \\ding{{53}} & {filter} \\\\*\n'
+            tablestr += f'\\verb+ProjectedAperture/{radius}kpc/projP+ & \\verb+projected_aperture_{radius}kpc_projP+ & \\ding{{53}} & {filter} \\\\*\n'
+        # Add others groups
+        tablestr += f'\\verb+SOAP+ & \\verb+soap+ & - & - \\\\*\n'
+        tablestr += f'\\verb+InputHalos+ & \\verb+input_halos+ & - & - \\\\*\n'
+        halo_finder = parameters['HaloFinder']['type']
+        tablestr += f'\\verb+InputHalos/{halo_finder}+ & \\verb+input_halos_{halo_finder.lower()}+ & - & - \\\\*\n'
+        if halo_finder == 'HBTplus':
+            tablestr += f'\\verb+InputHalos/FOF+ & \\verb+input_halos_fof+ & - & - \\\\*\n'
         # Finish table and output to file
         tablestr += '\\end{adjustbox}\n\\newpage'
         with open(f"{output_dir}/variations_table.tex", "w") as ofile:

--- a/scripts/COLIBRE/group_membership.sh
+++ b/scripts/COLIBRE/group_membership.sh
@@ -21,6 +21,8 @@
 #SBATCH -t 0:30:00
 #
 
+set -e
+
 module purge
 module load python/3.12.4 gnu_comp/14.1.0 openmpi/5.0.3 parallel_hdf5/1.12.3
 source openmpi-5.0.3-hdf5-1.12.3-env/bin/activate

--- a/scripts/COLIBRE/halo_properties.sh
+++ b/scripts/COLIBRE/halo_properties.sh
@@ -22,6 +22,8 @@
 #SBATCH -t 04:00:00
 #
 
+set -e
+
 module purge
 module load python/3.12.4 gnu_comp/14.1.0 openmpi/5.0.3 parallel_hdf5/1.12.3
 source openmpi-5.0.3-hdf5-1.12.3-env/bin/activate

--- a/scripts/FLAMINGO/L1000N0900/compress_group_membership_L1000N0900.sh
+++ b/scripts/FLAMINGO/L1000N0900/compress_group_membership_L1000N0900.sh
@@ -88,11 +88,8 @@ echo Compressing ${nr_files} group membership files
 echo Source     : ${input_filename}
 echo Destination: ${output_filename}
 
-seq 0 ${nr_files_minus_one} | parallel -j 32 \
-  h5repack \
-    -i "${input_filename}.{}.hdf5" \
-    -o "${output_filename}.{}.hdf5" \
-    -l CHUNK=10000 -f GZIP=9
+seq 0 ${nr_files_minus_one} | xargs -I {} -P 32 bash -c \
+  "h5repack -i ${input_filename}.{}.hdf5 -o ${output_filename}.{}.hdf5 -l CHUNK=10000 -f GZIP=4"
 
 echo Done.
 

--- a/scripts/FLAMINGO/L1000N0900/compress_group_membership_L1000N0900.sh
+++ b/scripts/FLAMINGO/L1000N0900/compress_group_membership_L1000N0900.sh
@@ -24,6 +24,8 @@
 #SBATCH -t 02:00:00
 #
 
+set -e
+
 module purge
 module load python/3.12.4 gnu_comp/14.1.0 openmpi/5.0.3 parallel_hdf5/1.12.3
 source openmpi-5.0.3-hdf5-1.12.3-env/bin/activate
@@ -91,5 +93,7 @@ echo Destination: ${output_filename}
 seq 0 ${nr_files_minus_one} | xargs -I {} -P 32 bash -c \
   "h5repack -i ${input_filename}.{}.hdf5 -o ${output_filename}.{}.hdf5 -l CHUNK=10000 -f GZIP=4"
 
-echo Done.
+chmod a=r "${output_filename}*"
+
+echo "Job complete!"
 

--- a/scripts/FLAMINGO/L1000N0900/compress_halo_properties_L1000N0900.sh
+++ b/scripts/FLAMINGO/L1000N0900/compress_halo_properties_L1000N0900.sh
@@ -24,6 +24,8 @@
 #SBATCH -t 01:00:00
 #
 
+set -e
+
 module purge
 module load python/3.12.4 gnu_comp/14.1.0 openmpi/5.0.3 parallel_hdf5/1.12.3
 source openmpi-5.0.3-hdf5-1.12.3-env/bin/activate
@@ -79,5 +81,7 @@ scratch_dir="${scratch_dir}/${sim}/SOAP_compression_tmp/"
 
 # run the script using all available threads on the node
 python3 ${script} --nproc 128 ${input_filename} ${output_filename} ${scratch_dir}
+
+chmod a=r ${output_filename}
 
 echo "Job complete!"

--- a/scripts/FLAMINGO/L1000N1800/compress_group_membership_L1000N1800.sh
+++ b/scripts/FLAMINGO/L1000N1800/compress_group_membership_L1000N1800.sh
@@ -88,11 +88,8 @@ echo Compressing ${nr_files} group membership files
 echo Source     : ${input_filename}
 echo Destination: ${output_filename}
 
-seq 0 ${nr_files_minus_one} | parallel -j 32 \
-  h5repack \
-    -i "${input_filename}.{}.hdf5" \
-    -o "${output_filename}.{}.hdf5" \
-    -l CHUNK=10000 -f GZIP=9
+seq 0 ${nr_files_minus_one} | xargs -I {} -P 32 bash -c \
+  "h5repack -i ${input_filename}.{}.hdf5 -o ${output_filename}.{}.hdf5 -l CHUNK=10000 -f GZIP=4"
 
 echo Done.
 

--- a/scripts/FLAMINGO/L1000N1800/compress_group_membership_L1000N1800.sh
+++ b/scripts/FLAMINGO/L1000N1800/compress_group_membership_L1000N1800.sh
@@ -24,6 +24,8 @@
 #SBATCH -t 02:00:00
 #
 
+set -e
+
 module purge
 module load python/3.12.4 gnu_comp/14.1.0 openmpi/5.0.3 parallel_hdf5/1.12.3
 source openmpi-5.0.3-hdf5-1.12.3-env/bin/activate
@@ -91,5 +93,7 @@ echo Destination: ${output_filename}
 seq 0 ${nr_files_minus_one} | xargs -I {} -P 32 bash -c \
   "h5repack -i ${input_filename}.{}.hdf5 -o ${output_filename}.{}.hdf5 -l CHUNK=10000 -f GZIP=4"
 
-echo Done.
+chmod a=r "${output_filename}*"
+
+echo "Job complete!"
 

--- a/scripts/FLAMINGO/L1000N1800/compress_halo_properties_L1000N1800.sh
+++ b/scripts/FLAMINGO/L1000N1800/compress_halo_properties_L1000N1800.sh
@@ -83,4 +83,6 @@ scratch_dir="${scratch_dir}/${sim}/SOAP_compression_tmp/"
 # run the script using all available threads on the node
 python3 ${script} --nproc 128 ${input_filename} ${output_filename} ${scratch_dir}
 
+chmod a=r ${output_filename}
+
 echo "Job complete!"

--- a/snapshot_datasets.py
+++ b/snapshot_datasets.py
@@ -19,6 +19,8 @@ import h5py
 from typing import Dict
 from numpy.typing import NDArray
 
+import property_table
+
 
 class SnapshotDatasets:
     """
@@ -167,9 +169,11 @@ class SnapshotDatasets:
             ptype, dset = self.dataset_map[name]
         except KeyError as e:
             print(f'Dataset "{name}" not found!')
-            print("Available datasets:")
-            for key in self.dataset_map:
-                print(f"  {key}")
+            print("The following properties require this dataset:")
+            full_property_list = property_table.PropertyTable.full_property_list
+            for k, v in full_property_list.items():
+                if name in v[8]:
+                    print(k)
             raise e
         return data_dict[ptype][dset]
 

--- a/swift_cells.py
+++ b/swift_cells.py
@@ -232,6 +232,12 @@ class SWIFTCellGrid:
                 float(self.parameters.get("Gravity:max_physical_nu_softening", 0)),
             ) * self.get_unit("code_length")
 
+            # Try to read in AGN_delta_T. We assert we have a valid value when we
+            # create the recently_heated_gas_filter
+            self.AGN_delta_T = float(
+                self.parameters.get("EAGLEAGN:AGN_delta_T_K", 0)
+            ) * self.get_unit('K')
+
             # Compute mean density at the redshift of the snapshot:
             # Here we compute the mean density in internal units at z=0 using
             # constants from the snapshot. The comoving mean density is

--- a/tests/FLAMINGO/parameters.yml
+++ b/tests/FLAMINGO/parameters.yml
@@ -526,3 +526,6 @@ calculations:
     min_halo_mass: 1e13
     halo_bin_size_dex: .05
     halos_per_bin: 200
+  recently_heated_gas_filter:
+    delta_time_myr: 15
+    use_AGN_delta_T: true


### PR DESCRIPTION
The gas filters in SOAP were hard-coded. This PR moves the definitions to the parameter file.
- For FLAMINGO we were using a hard-coded value of `AGN_delta_T`. This is now read from the snapshot
- The delta_time for considering a particle to be recently heated is now defined in the parameter file.
- For COLIBRE we only want to use the time to determine if a particle was recently heated. This can be specified in the parameter file.
- Limits for the ColdDenseGasFilter are now defined in the parameter file. If these values are missing, and a property requires the ColdDenseGasFilter, the code will error.
- If an error is raised because a required dataset cannot be found, a list of all the properties which use that dataset will be output