### PR TITLE
FOF virtual file fix

### DIFF
--- a/documentation/SOAP.tex
+++ b/documentation/SOAP.tex
@@ -26,7 +26,7 @@
 \section{Introduction}
 
 SOAP computes different types of properties, depending on  how particles are included (by radius, in projection...). 
-For all types, we use the halo membership and centre of potential as determined by the input halo catalogue. 
+For all types, we use the halo membership and halo centre as determined by the input halo catalogue. 
 This documentation is generated using the SOAP parameter file, and so the properties listed reflect those
 present in the current run of SOAP, rather than all possible properties.
 
@@ -57,7 +57,7 @@ corresponds to a particular projection direction (\verb+x+, \verb+y+ or \verb+z+
 
 \paragraph{Spherical overdensity properties (SO)} are fundamentally different from the three other types in 
 that their aperture radius is determined from the density profile and is different for different halos. They 
-always include all particles within a sphere around the centre of potential, regardless of halo membership. 
+always include all particles within a sphere around the halo centre, regardless of halo membership. 
 The radius is either the radius at which the density reaches a certain target value (50 crit, 100 crit, 200 
 crit, 500 crit, 1000 crit, 2500 crit, 200 mean, BN98) or a multiple of such a radius (5xR 500 crit). Details 
 of the spherical overdensity calculation are given at the end of this document. Spherical overdensities are 
@@ -223,7 +223,7 @@ For clarity, this is the full set of rules for determining the SO radius in SOAP
 \begin{enumerate}
     \item Sort particles according to radius and construct the cumulative mass profile.
     \item Discard any particles at zero radius, since we cannot compute a density for those. The mass of these 
-    particles is used as an $r=0$ offset for the cumulative mass profile. Since the centre of potential is the 
+    particles is used as an $r=0$ offset for the cumulative mass profile. Since the halos centre is the 
     position of the most bound particle, there should always be at least one such particle.
     \item Construct the density profile by dividing the cumulative mass at every radius by the volume of the 
     sphere with that radius.
@@ -232,7 +232,7 @@ For clarity, this is the full set of rules for determining the SO radius in SOAP
     \begin{enumerate}
         \item If there are none, analytically compute $R_{\rm{}SO}=\sqrt{3M_1/(4\pi{}R_1\rho_{\rm{}target})}$, 
         where $R_1$ and $M_1$ are the first non zero radius and the corresponding cumulative mass. This is a 
-        special case of Eq. (\ref{eq:RSO}). Unless there are multiple particles at the exact centre of potential 
+        special case of Eq. (\ref{eq:RSO}). Unless there are multiple particles at the exact halo centre 
         position, this radius estimate will then be based on just two particles.
         \item In all other cases, we use $R_{1,2}$ and $M_{1,2}$ as input for Eq. (\ref{eq:RSO}) and solve for 
         $R_{\rm{}SO}$. The only exception is the special case where $R_1 = R_2$. If that happens, we simply 

--- a/documentation/SOAP.tex
+++ b/documentation/SOAP.tex
@@ -223,7 +223,7 @@ For clarity, this is the full set of rules for determining the SO radius in SOAP
 \begin{enumerate}
     \item Sort particles according to radius and construct the cumulative mass profile.
     \item Discard any particles at zero radius, since we cannot compute a density for those. The mass of these 
-    particles is used as an $r=0$ offset for the cumulative mass profile. Since the halos centre is the 
+    particles is used as an $r=0$ offset for the cumulative mass profile. Since the halo's centre is the 
     position of the most bound particle, there should always be at least one such particle.
     \item Construct the density profile by dividing the cumulative mass at every radius by the volume of the 
     sphere with that radius.
@@ -287,7 +287,7 @@ snapshots. Each group contains the following datasets:
 \end{enumerate}
 
 The GroupNr values stored here are zero based array indexes into the
-full subhalo catalogue, and not the subhalos IDs. For example the first group
+full subhalo catalogue, and not the subhalo's IDs. For example the first group
 in the VELOCIraptor catalogue has GroupNr=0 and ID=1.
 
 The script `make\_virtual\_snapshot.py` will combine snapshot and group membership files

--- a/documentation/footnote_AngMom.tex
+++ b/documentation/footnote_AngMom.tex
@@ -1,5 +1,5 @@
 \paragraph{$^{$FOOTNOTE_NUMBER$}$The angular momentum} of gas, dark matter and stars is computed relative to 
-the centre of potential (cop) and the centre of mass velocity of that particular component, and not to to the 
+the halo centre (cop) and the centre of mass velocity of that particular component, and not to to the 
 total centre of mass velocity. The full expression is
 
 \begin{equation}

--- a/documentation/footnote_AngMom.tex
+++ b/documentation/footnote_AngMom.tex
@@ -1,5 +1,5 @@
 \paragraph{$^{$FOOTNOTE_NUMBER$}$The angular momentum} of gas, dark matter and stars is computed relative to 
-the halo centre (cop) and the centre of mass velocity of that particular component, and not to to the 
+the halo centre (cop) and the centre of mass velocity of that particular component, and not to the 
 total centre of mass velocity. The full expression is
 
 \begin{equation}

--- a/documentation/footnote_circvel.tex
+++ b/documentation/footnote_circvel.tex
@@ -6,7 +6,7 @@ computed using
 \end{equation}
 
 where the cumulative mass $M(\leq{}r)$ includes all particles within the radius $r$, and includes the
-contribution of the particle(s) at $r=0$. The radius is computed relative to the centre of potential.
+contribution of the particle(s) at $r=0$. The radius is computed relative to the halo centre.
 The softened $v_{\rm{}max}$ value is calculated using the same method, except the particle
 radius has a floor of the softening length. An alternative way to calculate $v_{\rm{}max}$
 is to estimate it from the halo concentration by assuming an NFW profile. We store the radius of the

--- a/documentation/footnote_compY.tex
+++ b/documentation/footnote_compY.tex
@@ -1,10 +1,10 @@
 \paragraph{$^{$FOOTNOTE_NUMBER$}$The Compton y parameter} is computed as in McCarthy et al. (2017):
 
 \begin{equation}
-    y = \sum_i \frac{\sigma{}_T}{m_e c^2} n_{e,i} k_B T_{e,i} \frac{m_i}{\rho{}_i},
+    y \, {d_A}^2(z) = \sum_i \frac{\sigma{}_T}{m_e c^2} n_{e,i} k_B T_{e,i} V_i,
 \end{equation}
 
-where $\sigma{}_T$ is the Thomson cross section, $m_e$ the electron mass, $c$ the speed of light and $k_B$ the 
+where $d_A(z)$ is the angular diameter distance, $\sigma{}_T$ is the Thomson cross section, $m_e$ the electron mass, $c$ the speed of light and $k_B$ the 
 Boltzmann constant. $n_{e,i}$ and $T_{e,i}$ are the electron number density and electron temperature for gas 
 particle $i$, while $V_i=m_i/\rho{}_i$ is the SPH volume element that turns the sum over all particles $i$ 
 within the inclusive sphere into a volume integral. Note that the snapshot already contains the individual 

--- a/documentation/footnote_spin.tex
+++ b/documentation/footnote_spin.tex
@@ -5,6 +5,6 @@
 \end{equation}
 
 where $\vec{L}_{\rm{}tot}$ is the total angular momentum of all particles within radius $R$, and $M$ their 
-total mass. The angular momentum is computed relative to the centre of potential and the total centre of mass 
+total mass. The angular momentum is computed relative to the halo centre and the total centre of mass 
 velocity. Since subhalos do not have a natural radius associated with them, we use the radius where the softened
 $v_{\rm{}max}$ is reached.

--- a/make_virtual_snapshot.py
+++ b/make_virtual_snapshot.py
@@ -60,6 +60,7 @@ def make_virtual_snapshot(snapshot, membership, output_file, snap_nr):
                 layout_grnr_all = h5py.VirtualLayout(shape=full_shape, dtype=dtype)
             if have_grnr_bound:
                 layout_grnr_bound = h5py.VirtualLayout(shape=full_shape, dtype=dtype)
+                layout_halo_catalogue_index = h5py.VirtualLayout(shape=full_shape, dtype=dtype)
             if have_rank_bound:
                 layout_rank_bound = h5py.VirtualLayout(shape=full_shape, dtype=dtype)
             # PartType6 (neutrinos) are not assigned a FOF group
@@ -94,6 +95,12 @@ def make_virtual_snapshot(snapshot, membership, output_file, snap_nr):
             if have_grnr_bound:
                 outfile.create_virtual_dataset(
                     f"PartType{ptype}/GroupNr_bound", layout_grnr_bound, fillvalue=-999
+                )
+                layout_halo_catalogue_index[:] = h5py.VirtualSource(outfile.filename,
+                    f"PartType{ptype}/GroupNr_bound", shape=full_shape
+                )
+                outfile.create_virtual_dataset(
+                    f"PartType{ptype}/HaloCatalogueIndex", layout_halo_catalogue_index, fillvalue=-999
                 )
             if have_rank_bound:
                 outfile.create_virtual_dataset(

--- a/make_virtual_snapshot.py
+++ b/make_virtual_snapshot.py
@@ -60,7 +60,6 @@ def make_virtual_snapshot(snapshot, membership, output_file, snap_nr):
                 layout_grnr_all = h5py.VirtualLayout(shape=full_shape, dtype=dtype)
             if have_grnr_bound:
                 layout_grnr_bound = h5py.VirtualLayout(shape=full_shape, dtype=dtype)
-                layout_halo_catalogue_index = h5py.VirtualLayout(shape=full_shape, dtype=dtype)
             if have_rank_bound:
                 layout_rank_bound = h5py.VirtualLayout(shape=full_shape, dtype=dtype)
             # PartType6 (neutrinos) are not assigned a FOF group
@@ -93,15 +92,10 @@ def make_virtual_snapshot(snapshot, membership, output_file, snap_nr):
                     f"PartType{ptype}/GroupNr_all", layout_grnr_all, fillvalue=-999
                 )
             if have_grnr_bound:
-                outfile.create_virtual_dataset(
+                dset_groupnr_bound = outfile.create_virtual_dataset(
                     f"PartType{ptype}/GroupNr_bound", layout_grnr_bound, fillvalue=-999
                 )
-                layout_halo_catalogue_index[:] = h5py.VirtualSource(outfile.filename,
-                    f"PartType{ptype}/GroupNr_bound", shape=full_shape
-                )
-                outfile.create_virtual_dataset(
-                    f"PartType{ptype}/HaloCatalogueIndex", layout_halo_catalogue_index, fillvalue=-999
-                )
+                outfile[f"PartType{ptype}/HaloCatalogueIndex"] = dset_groupnr_bound
                 for k, v in outfile[f"PartType{ptype}/GroupNr_bound"].attrs.items():
                     outfile[f"PartType{ptype}/HaloCatalogueIndex"].attrs[k] = v
             if have_rank_bound:

--- a/make_virtual_snapshot.py
+++ b/make_virtual_snapshot.py
@@ -102,6 +102,8 @@ def make_virtual_snapshot(snapshot, membership, output_file, snap_nr):
                 outfile.create_virtual_dataset(
                     f"PartType{ptype}/HaloCatalogueIndex", layout_halo_catalogue_index, fillvalue=-999
                 )
+                for k, v in outfile[f"PartType{ptype}/GroupNr_bound"].attrs.items():
+                    outfile[f"PartType{ptype}/HaloCatalogueIndex"].attrs[k] = v
             if have_rank_bound:
                 outfile.create_virtual_dataset(
                     f"PartType{ptype}/Rank_bound", layout_rank_bound, fillvalue=-999

--- a/update_vds_paths.py
+++ b/update_vds_paths.py
@@ -83,8 +83,13 @@ def update_virtual_snapshot_paths(filename, snapshot_dir=None, membership_dir=No
     for dset in all_datasets:
         if dset.is_virtual:
             name = dset.name.split("/")[-1]
-            if name in ("GroupNr_all", "GroupNr_bound", "Rank_bound", "FOFGroupIDs"):
+            if name in ("GroupNr_all", "GroupNr_bound", "Rank_bound"):
                 # Data comes from the membership files
+                if membership_dir is not None:
+                    update_vds_paths(dset, replace_membership_path)
+            elif (name == "FOFGroupIDs") and ("PartType1/FOFGroupIDs_old" in f):
+                print('updating fof id')
+                # FOF IDs come from membership files
                 if membership_dir is not None:
                     update_vds_paths(dset, replace_membership_path)
             else:

--- a/update_vds_paths.py
+++ b/update_vds_paths.py
@@ -83,17 +83,20 @@ def update_virtual_snapshot_paths(filename, snapshot_dir=None, membership_dir=No
     for dset in all_datasets:
         if dset.is_virtual:
             name = dset.name.split("/")[-1]
+            # Skip dataset if it points somewhere else within the virtual file
+            vsources = dset.virtual_sources()
+            if (len(vsources) == 1) and (vsources[0].file_name == '.'):
+                continue
+            # Data comes from the membership files
             if name in ("GroupNr_all", "GroupNr_bound", "Rank_bound"):
-                # Data comes from the membership files
                 if membership_dir is not None:
                     update_vds_paths(dset, replace_membership_path)
+            # FOF IDs come from membership files
             elif (name == "FOFGroupIDs") and ("PartType1/FOFGroupIDs_old" in f):
-                print('updating fof id')
-                # FOF IDs come from membership files
                 if membership_dir is not None:
                     update_vds_paths(dset, replace_membership_path)
+            # Data comes from the snapshot files
             else:
-                # Data comes from the snapshot files
                 if snapshot_dir is not None:
                     update_vds_paths(dset, replace_snapshot_path)
 

--- a/update_vds_paths.py
+++ b/update_vds_paths.py
@@ -83,10 +83,6 @@ def update_virtual_snapshot_paths(filename, snapshot_dir=None, membership_dir=No
     for dset in all_datasets:
         if dset.is_virtual:
             name = dset.name.split("/")[-1]
-            # Skip dataset if it points somewhere else within the virtual file
-            vsources = dset.virtual_sources()
-            if (len(vsources) == 1) and (vsources[0].file_name == '.'):
-                continue
             # Data comes from the membership files
             if name in ("GroupNr_all", "GroupNr_bound", "Rank_bound"):
                 if membership_dir is not None:


### PR DESCRIPTION
Changes
- For DMO runs we want to use the FOF IDs from the snapshots, but I was updating the virtual source to always point to the membership file.
- When we create virtual files I am adding a field called `HaloCatalogueIndex`, which is just a link to `GroupNr_bound`.
- Make some minor corrections to the docs