### PR TITLE
Read header to decide whether to run in snipshot mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ openmpi-5.0.3-hdf5-1.12.3-env
 documentation/SOAP.aux
 documentation/SOAP.log
 documentation/SOAP.pdf
+documentation/SOAP.out
 documentation/filters.tex
 documentation/footnotes.tex
 documentation/table.tex

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -130,6 +130,8 @@ def compute_halo_properties():
     )
 
     # Process parameter file
+    if args.snipshot is None:
+        args.snipshot = cellgrid.snipshot
     if comm_world_rank == 0:
         parameter_file = ParameterFile(file_name=args.config_filename, snipshot=args.snipshot)
     else:

--- a/documentation/SOAP.tex
+++ b/documentation/SOAP.tex
@@ -178,6 +178,9 @@ For example, a property whose units are listed as M/t will have units of velocit
 where $1 \, \rm{M/t} = \velbaseunit \, \rm{km/s}$.
 The scale factor is explicitly included for comoving properties (e.g. the units of HaloCentre are aL)
 
+If a property is being calculated for a certain halo type it is marked with a \ding{51}. Properties calculated
+for snapshots but not snipshots are indicated with a \ding{36}.
+
 \input{table}
 
 \section{Non-trivial properties}

--- a/property_table.py
+++ b/property_table.py
@@ -3998,13 +3998,14 @@ class PropertyTable:
         else:
             return ""
 
-    def __init__(self, parameters):
+    def __init__(self, parameters, snipshot_parameters):
         """
         Constructor.
         """
         self.properties = {}
         self.footnotes = []
         self.parameters = parameters
+        self.snipshot_parameters = snipshot_parameters
 
     def add_properties(self, halo_property: HaloProperty, halo_type: str):
         """
@@ -4017,6 +4018,7 @@ class PropertyTable:
         if halo_type in ['ExclusiveSphereProperties', 'InclusiveSphereProperties']:
             base_halo_type = 'ApertureProperties'
         property_mask = self.parameters.get_property_mask(base_halo_type, [prop[1] for prop in props])
+        snipshot_mask = self.snipshot_parameters.get_property_mask(base_halo_type, [prop[1] for prop in props])
 
         # Loop through all possible properties for this halo type and add them to the
         # table, skipping those that we shouldn't calculate according to the parameter file
@@ -4082,7 +4084,11 @@ class PropertyTable:
                     print(halo_type, prop_name, prop_cat, self.properties[prop_name])
                     exit()
                 assert prop_outputname == self.properties[prop_name]["name"]
-                self.properties[prop_name]["types"].append(halo_type)
+
+                if not snipshot_mask[prop_outputname]:
+                    self.properties[prop_name]["types"].append('SnapshotOnly'+halo_type)
+                else:
+                    self.properties[prop_name]["types"].append(halo_type)
             else:
                 self.properties[prop_name] = {
                     "name": prop_outputname,
@@ -4093,9 +4099,12 @@ class PropertyTable:
                     "category": prop_cat,
                     "compression": prop_comp,
                     "dmo": prop_dmo,
-                    "types": [halo_type],
                     "raw": props[i],
                 }
+                if not snipshot_mask[prop_outputname]:
+                    self.properties[prop_name]["types"] = ['SnapshotOnly'+halo_type]
+                else:
+                    self.properties[prop_name]["types"] = [halo_type]
 
     def print_dictionary(self):
         """
@@ -4193,17 +4202,17 @@ Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category & Compression\\\
 
             checkmark = "\\ding{51}"
             xmark = "\\ding{53}"
+            scissor = "\\ding{36}"
             prop_subhalo = checkmark if "SubhaloProperties" in prop["types"] else xmark
-            prop_exclusive = (
-                checkmark if "ExclusiveSphereProperties" in prop["types"] else xmark
-            )
-            prop_inclusive = (
-                checkmark if "InclusiveSphereProperties" in prop["types"] else xmark
-            )
-            prop_projected = (
-                checkmark if "ProjectedApertureProperties" in prop["types"] else xmark
-            )
+            prop_subhalo = scissor if 'SnapshotOnlySubhaloProperties' in prop["types"] else prop_subhalo
+            prop_exclusive = checkmark if "ExclusiveSphereProperties" in prop["types"] else xmark
+            prop_exclusive = scissor if "SnapshotOnlyExclusiveSphereProperties" in prop["types"] else prop_exclusive 
+            prop_inclusive = checkmark if "InclusiveSphereProperties" in prop["types"] else xmark
+            prop_inclusive = scissor if "SnapshotOnlyInclusiveSphereProperties" in prop["types"] else prop_inclusive 
+            prop_projected = checkmark if "ProjectedApertureProperties" in prop["types"] else xmark
+            prop_projected = scissor if "SnapshotOnlyProjectedApertureProperties" in prop["types"] else prop_projected
             prop_SO = checkmark if "SOProperties" in prop["types"] else xmark
+            prop_SO = scissor if "SnapshotOnlySOProperties" in prop["types"] else prop_SO
             table_props = [
                 prop_outputname,
                 prop_shape,
@@ -4351,7 +4360,8 @@ if __name__ == "__main__":
 
     # Parse parameter file
     try:
-        parameters = ParameterFile(file_name=sys.argv[1])
+        parameters = ParameterFile(file_name=sys.argv[1], snipshot=False)
+        snipshot_parameters = ParameterFile(file_name=sys.argv[1], snipshot=True)
     except IndexError:
         print("A valid parameter file was not passed.")
         exit()
@@ -4389,7 +4399,7 @@ if __name__ == "__main__":
     # Define scale factor unit
     unyt.define_unit('a', 1*unyt.dimensionless, tex_repr='\\rm{a}')
 
-    table = PropertyTable(parameters)
+    table = PropertyTable(parameters, snipshot_parameters)
     # Add standard halo definitions
     table.add_properties(SubhaloProperties, "SubhaloProperties")
     table.add_properties(ExclusiveSphereProperties, "ExclusiveSphereProperties")

--- a/soap_args.py
+++ b/soap_args.py
@@ -40,6 +40,7 @@ def get_soap_args(comm):
     parser.add_argument("--max-ranks-reading", type=int, default=32, help="Number of ranks per node reading snapshot data")
     parser.add_argument("--output-parameters", type=str, default='', help="Where to write the used parameters")
     parser.add_argument("--snipshot", action="store_true", help="Run in snipshot mode")
+    parser.add_argument("--snapshot", action="store_true", help="Run in snapshot mode")
     all_args = parser.parse_args()
 
     # Combine with parameters from configuration file
@@ -73,7 +74,18 @@ def get_soap_args(comm):
     args.git_hash = all_args["git_hash"]
     args.min_read_radius_cmpc = all_args["calculations"]["min_read_radius_cmpc"]
     args.calculations = all_args["calculations"]
-    args.snipshot = all_args["Parameters"]["snipshot"]
+
+    # The default behaviour is to determine whether to run in snipshot mode
+    # by looking at the value of "SelectOutut" in the snapshot header.
+    # Passing --snipshot or --snapshot will override this
+    if all_args["Parameters"]["snipshot"]:
+        args.snipshot = True
+        assert not all_args["Parameters"]["snapshot"], 'You cannot pass both --snapshot and --snipshot'
+    elif all_args["Parameters"]["snapshot"]:
+        args.snipshot = False
+    else:
+        # We will set the value of arg.snipshot later
+        args.snipshot = None
 
     # Check we can write to the halo properties file
     if comm.Get_rank() == 0:

--- a/swift_cells.py
+++ b/swift_cells.py
@@ -206,6 +206,9 @@ class SWIFTCellGrid:
             for name in infile["Header"].attrs:
                 self.swift_header_group[name] = infile["Header"].attrs[name]
 
+            # Determine if this is a snapshot or snipshot
+            self.snipshot = (self.swift_header_group["SelectOutput"] == "Snipshot")
+
             # Read the critical density and attach units
             # This is in internal units, which may not be the same as snapshot units.
             critical_density = float(


### PR DESCRIPTION
Previously we require that the user passed `--snipshot` when running SOAP if they want to run in snipshot mode. This PR reads the SWIFT header to determine whether to use snipshot mode. The user can still pass arguments at runtime if they want to override what is found in the header.

I have updated the documentation to indicate if a property is only available for snapshots and not snipshots.
![Screenshot from 2024-09-06 13-02-12](https://github.com/user-attachments/assets/8ded80a5-b48e-4378-bd73-b8fbf2148349)

