### PR TITLE
Squash bug in tensor calculation

### DIFF
--- a/combine_chunks.py
+++ b/combine_chunks.py
@@ -453,7 +453,7 @@ def combine_chunks(
             # Each rank determines which halos to keep
             reduced_snapshot = np.zeros(order.shape[0], dtype=np.int32)
             for i_bin in range(bins.shape[0]-1):
-                mask = (bins[i_bin] < mass) & (mass < bins[i_bin+1])
+                mask = (bins[i_bin] <= mass) & (mass < bins[i_bin+1])
                 idx = np.where(mask)[0]
                 assert n_keep[i_bin] <= np.sum(mask)
                 keep_idx = np.random.choice(idx, size=n_keep[i_bin], replace=False)

--- a/kinematic_properties.py
+++ b/kinematic_properties.py
@@ -303,7 +303,7 @@ def get_inertia_tensor(mass, position, sphere_radius, search_radius=None, reduce
         # We want to skip the calculation if we only only have a small number of particles
         # inside the initial sphere. We do the check here since this is the first time
         # we calculate how many particles are within the sphere.
-        if (i_iter == 0) and (np.sum(mass[r <= 1]) < 20):
+        if (i_iter == 0) and (np.sum(r <= 1) < 20):
             return None
         weight = mass / np.sum(mass[r <= 1])
         weight[r > 1] = 0


### PR DESCRIPTION
This PR fixes two bugs. 

- When creating reduced snapshots I was missing any objects with a mass equal to a the bin edge. This caused a crash for a single flamingo snapshot due to the assert two lines later.
- When calculating inertia tensors there is a check to see if we have at least 20 particle in the initial sphere. This was being done by summing the mass. This wasn't a big issue for Flamingo since particle masses aren't that far from 1, but for Colibre many objects were being skipped. 