### PR TITLE
Add header to membership files

### DIFF
--- a/combine_chunks.py
+++ b/combine_chunks.py
@@ -192,7 +192,7 @@ def combine_chunks(
             n_part_type = cellgrid.swift_header_group["NumPartTypes"][0]
             header.attrs["NumPart_ThisFile"] = np.zeros(n_part_type, dtype="int32")
             header.attrs["NumPart_Total"] = np.zeros(n_part_type, dtype="uint32")
-            header.attrs["NumPart_Total_Highword"] = np.zeros(
+            header.attrs["NumPart_Total_HighWord"] = np.zeros(
                 n_part_type, dtype="uint32"
             )
             header.attrs["OutputType"] = "SOAP"

--- a/documentation/SOAP.tex
+++ b/documentation/SOAP.tex
@@ -31,7 +31,7 @@ For all types, we use the halo membership and halo centre as determined by the i
 This documentation is generated using the SOAP parameter file, and so the properties listed reflect those
 present in the current run of SOAP, rather than all possible properties.
 
-For loading SOAP catalogues we recommend using the \verb|load_fof_catalogues| branch of \href{https://github.com/SWIFTSIM/swiftsimio/tree/load\_fof\_catalogues}{swiftsimio}. A simple example is:
+For loading SOAP catalogues we recommend using the swiftsimio package. A simple example is:
 \begin{verbatim}
 import swiftsimio as sw
 soap_dir = '/cosma8/data/dp004/flamingo/Runs/L1000N1800/HYDRO_FIDUCIAL/SOAP-HBT/'

--- a/make_virtual_snapshot.py
+++ b/make_virtual_snapshot.py
@@ -92,10 +92,13 @@ def make_virtual_snapshot(snapshot, membership, output_file, snap_nr):
                     f"PartType{ptype}/GroupNr_all", layout_grnr_all, fillvalue=-999
                 )
             if have_grnr_bound:
-                dset_groupnr_bound = outfile.create_virtual_dataset(
+                outfile.create_virtual_dataset(
                     f"PartType{ptype}/GroupNr_bound", layout_grnr_bound, fillvalue=-999
                 )
-                outfile[f"PartType{ptype}/HaloCatalogueIndex"] = dset_groupnr_bound
+                # Copy GroupNr_bound to HaloCatalogueIndex, since that is the name in SOAP
+                outfile.create_virtual_dataset(
+                    f"PartType{ptype}/HaloCatalogueIndex", layout_grnr_bound, fillvalue=-999
+                )
                 for k, v in outfile[f"PartType{ptype}/GroupNr_bound"].attrs.items():
                     outfile[f"PartType{ptype}/HaloCatalogueIndex"].attrs[k] = v
             if have_rank_bound:

--- a/scripts/COLIBRE/compress_group_membership.sh
+++ b/scripts/COLIBRE/compress_group_membership.sh
@@ -93,5 +93,8 @@ membership="${output_filename}.{file_nr}.hdf5"
 virtual="${outbase}/colibre_with_SOAP_membership_${snapnum}.hdf5"
 python make_virtual_snapshot.py $snapshot $membership $virtual
 
+echo "Setting virtual file to be read-only"
+chmod a=r "${virtual}"
+
 echo "Job complete!"
 

--- a/scripts/COLIBRE/compress_halo_properties.sh
+++ b/scripts/COLIBRE/compress_halo_properties.sh
@@ -55,7 +55,7 @@ sim="${SLURM_JOB_NAME}"
 script="./compression/compress_fast_metadata.py"
 
 # Location of the input to compress
-inbase="${output_dir}/${sim}/SOAP_uncompressed/"
+inbase="${scratch_dir}/${sim}/SOAP_uncompressed/"
 
 # Location of the compressed output
 outbase="${output_dir}/${sim}/SOAP/"

--- a/subhalo_properties.py
+++ b/subhalo_properties.py
@@ -2105,7 +2105,7 @@ class SubhaloProperties(HaloProperty):
             )
         elif Ntot > Nexpected:
             # This would indicate a bug somewhere
-            raise RuntimeError("Found more particles than expected!")
+            raise RuntimeError(f'Found more particles than expected for halo {input_halo["index"]}')
 
         # Add these properties to the output
         for prop in self.property_list:

--- a/update_vds_paths.py
+++ b/update_vds_paths.py
@@ -84,7 +84,7 @@ def update_virtual_snapshot_paths(filename, snapshot_dir=None, membership_dir=No
         if dset.is_virtual:
             name = dset.name.split("/")[-1]
             # Data comes from the membership files
-            if name in ("GroupNr_all", "GroupNr_bound", "Rank_bound"):
+            if name in ("GroupNr_all", "GroupNr_bound", "Rank_bound", "HaloCatalogueIndex"):
                 if membership_dir is not None:
                     update_vds_paths(dset, replace_membership_path)
             # FOF IDs come from membership files


### PR DESCRIPTION
This PR adds a header to the membership files we produce. The header will not be copied when a virtual snapshot is generated.

Other minor changes:
- Log halo ID when too many particles are found for a subhalo
- Set virtual snapshots to be read only after generating them