### PR TITLE
Fix scale factor for FOF data

### DIFF
--- a/combine_chunks.py
+++ b/combine_chunks.py
@@ -375,7 +375,12 @@ def combine_chunks(
             fof_file.read("Groups/Centres"), indices, comm=comm_world
         )
         props = PropertyTable.full_property_list[f"FOF/Centres"]
-        fof_com = (fof_com * fof_com_unit).to(cellgrid.get_unit(props[3]))
+        soap_com_unit = cellgrid.get_unit(props[3])
+        physical = props[9]
+        a_exponent = props[10]
+        if not physical:
+            soap_com_unit = soap_com_unit * cellgrid.get_unit('a') ** a_exponent
+        fof_com = (fof_com * fof_com_unit).to(soap_com_unit)
         phdf5.collective_write(
             outfile,
             "InputHalos/FOF/Centres",
@@ -389,7 +394,12 @@ def combine_chunks(
             fof_file.read("Groups/Masses"), indices, comm=comm_world
         )
         props = PropertyTable.full_property_list[f"FOF/Masses"]
-        fof_mass = (fof_mass * fof_mass_unit).to(cellgrid.get_unit(props[3]))
+        soap_mass_unit = cellgrid.get_unit(props[3])
+        physical = props[9]
+        a_exponent = props[10]
+        if not physical:
+            soap_mass_unit = soap_mass_unit * cellgrid.get_unit('a') ** a_exponent
+        fof_mass = (fof_mass * fof_mass_unit).to(soap_mass_unit)
         phdf5.collective_write(
             outfile,
             "InputHalos/FOF/Masses",

--- a/parameter_files/FLAMINGO.yml
+++ b/parameter_files/FLAMINGO.yml
@@ -611,7 +611,7 @@ defined_constants:
   Fe_H_sun: 2.82e-5
 calculations:
   recalculate_xrays: true
-  xray_table_path: /snap8/scratch/dp004/dc-bras1/cloudy/X_Ray_table_metals_full.hdf5
+  xray_table_path: /cosma8/data/dp004/flamingo/Tables/Xray/X_Ray_table_metals_full.hdf5
   min_read_radius_cmpc: 5
   calculate_missing_properties: true
   reduced_snapshots:


### PR DESCRIPTION
When copying the FOF data I was not checking the scale factor when converting to the units specified in the property table.

Also updates the location of the FLAMINGO Xray tables