### PR TITLE
Update check that properties are valid

### DIFF
--- a/SOAP/compute_halo_properties.py
+++ b/SOAP/compute_halo_properties.py
@@ -448,7 +448,7 @@ def compute_halo_properties():
         if args.record_property_timings:
             print("Storing processing time for each property")
         parameter_file.print_unregistered_properties()
-        parameter_file.print_invalid_properties()
+        parameter_file.print_invalid_properties(halo_prop_list)
         category_filter.print_filters()
 
     # Ensure output dir exists

--- a/SOAP/particle_selection/SO_properties.py
+++ b/SOAP/particle_selection/SO_properties.py
@@ -3119,6 +3119,7 @@ class SOProperties(HaloProperty):
     Each property should have a corresponding method/property/lazy_property in
     the SOParticleData class above.
     """
+    base_halo_type = 'SOProperties'
     property_list = {
         name: PropertyTable.full_property_list[name]
         for name in [

--- a/SOAP/particle_selection/aperture_properties.py
+++ b/SOAP/particle_selection/aperture_properties.py
@@ -3087,6 +3087,7 @@ class ApertureProperties(HaloProperty):
     are bound to the halo.
     """
 
+    base_halo_type = 'ApertureProperties'
     # Properties to calculate for ApertureProperties. Key is the name of the property.
     # The value indicates the property has a direct dependence on aperture size.
     # This is needed since for larger apertures we sometimes copy across the

--- a/SOAP/particle_selection/projected_aperture_properties.py
+++ b/SOAP/particle_selection/projected_aperture_properties.py
@@ -1413,6 +1413,7 @@ class ProjectedApertureProperties(HaloProperty):
     the halo along the projection axis.
     """
 
+    base_halo_type = 'ProjectedApertureProperties'
     # Properties to calculate. The key is the name of the property,
     # the value indicates the property has a direct dependence on aperture size.
     # This is needed since for larger apertures we sometimes copy across the

--- a/SOAP/particle_selection/subhalo_properties.py
+++ b/SOAP/particle_selection/subhalo_properties.py
@@ -1797,6 +1797,7 @@ class SubhaloProperties(HaloProperty):
     Each property should have a corresponding method/property/lazy_property in
     the SubhaloParticleData class above.
     """
+    base_halo_type = 'SubhaloProperties'
     property_list = {
         prop: PropertyTable.full_property_list[prop]
         for prop in [

--- a/SOAP/property_table.py
+++ b/SOAP/property_table.py
@@ -4275,9 +4275,7 @@ class PropertyTable:
         # Get the property_filters dict, which says whether a property should be included,
         # and what category the property is in
         props = halo_property.property_list
-        base_halo_type = halo_type
-        if halo_type in ["ExclusiveSphereProperties", "InclusiveSphereProperties"]:
-            base_halo_type = "ApertureProperties"
+        base_halo_type = halo_property.base_halo_type
         if halo_type == "DummyProperties":
             property_filters = {
                 prop.name: prop.name.split("/")[0] for prop in props.values()
@@ -4614,6 +4612,7 @@ class DummyProperties:
     category (e.g. we have 'VR/ID' instead of 'ID')
     """
 
+    base_halo_type = 'DummyProperties'
     def __init__(self, halo_finder):
         categories = ["SOAP", "Input", halo_finder]
         # Currently FOF properties are only stored for HBT

--- a/parameter_files/COLIBRE_HYBRID.yml
+++ b/parameter_files/COLIBRE_HYBRID.yml
@@ -219,22 +219,6 @@ ApertureProperties:
     NumberOfDarkMatterParticles: true
     NumberOfGasParticles: true
     NumberOfStarParticles: true
-    TotalInertiaTensor: false
-    GasInertiaTensor: false
-    DarkMatterInertiaTensor: false
-    StellarInertiaTensor: false
-    TotalInertiaTensorReduced: false
-    GasInertiaTensorReduced: false
-    DarkMatterInertiaTensorReduced: false
-    StellarInertiaTensorReduced: false
-    TotalInertiaTensorNoniterative: general
-    GasInertiaTensorNoniterative: general
-    DarkMatterInertiaTensorNoniterative: general
-    StellarInertiaTensorNoniterative: general
-    TotalInertiaTensorReducedNoniterative: false
-    GasInertiaTensorReducedNoniterative: false
-    DarkMatterInertiaTensorReducedNoniterative: false
-    StellarInertiaTensorReducedNoniterative: false
     StarFormationRate: true
     AveragedStarFormationRate:
       snapshot: true
@@ -439,17 +423,11 @@ SOProperties:
       snapshot: true
       snipshot: false
     GasComptonYTemperature: false
-    GasComptonYTemperatureCoreExcision: false
     GasComptonYTemperatureWithoutRecentAGNHeating: false
-    GasComptonYTemperatureWithoutRecentAGNHeatingCoreExcision: false
     GasTemperature: true
-    GasTemperatureCoreExcision: false
     GasTemperatureWithoutCoolGas: true
     GasTemperatureWithoutCoolGasAndRecentAGNHeating: true
     GasTemperatureWithoutRecentAGNHeating: true
-    GasTemperatureWithoutCoolGasAndRecentAGNHeatingCoreExcision: false
-    GasTemperatureWithoutCoolGasCoreExcision: false
-    GasTemperatureWithoutRecentAGNHeatingCoreExcision: false
     HotGasMass: true
     KineticEnergyGas: general
     KineticEnergyStars: general
@@ -521,31 +499,21 @@ SOProperties:
     XRayLuminosity:
       snapshot: true
       snipshot: false
-    XRayLuminosityCoreExcision: false
     XRayLuminosityWithoutRecentAGNHeating:
       snapshot: true
       snipshot: false
-    XRayLuminosityWithoutRecentAGNHeatingCoreExcision: false
     XRayLuminosityInRestframe: false
-    XRayLuminosityInRestframeCoreExcision: false
     XRayLuminosityInRestframeWithoutRecentAGNHeating: false
-    XRayLuminosityInRestframeWithoutRecentAGNHeatingCoreExcision: false
     XRayPhotonLuminosity:
       snapshot: true
       snipshot: false
-    XRayPhotonLuminosityCoreExcision: false
     XRayPhotonLuminosityWithoutRecentAGNHeating:
       snapshot: true
       snipshot: false
-    XRayPhotonLuminosityWithoutRecentAGNHeatingCoreExcision: false
     XRayPhotonLuminosityInRestframe: false
-    XRayPhotonLuminosityInRestframeCoreExcision: false
     XRayPhotonLuminosityInRestframeWithoutRecentAGNHeating: false
-    XRayPhotonLuminosityInRestframeWithoutRecentAGNHeatingCoreExcision: false
     SpectroscopicLikeTemperature: true
-    SpectroscopicLikeTemperatureCoreExcision: false
     SpectroscopicLikeTemperatureWithoutRecentAGNHeating: true
-    SpectroscopicLikeTemperatureWithoutRecentAGNHeatingCoreExcision: false
     DarkMatterMassFlowRate: general
     ColdGasMassFlowRate: general
     CoolGasMassFlowRate: general

--- a/parameter_files/COLIBRE_THERMAL.yml
+++ b/parameter_files/COLIBRE_THERMAL.yml
@@ -219,22 +219,6 @@ ApertureProperties:
     NumberOfDarkMatterParticles: true
     NumberOfGasParticles: true
     NumberOfStarParticles: true
-    TotalInertiaTensor: false
-    GasInertiaTensor: false
-    DarkMatterInertiaTensor: false
-    StellarInertiaTensor: false
-    TotalInertiaTensorReduced: false
-    GasInertiaTensorReduced: false
-    DarkMatterInertiaTensorReduced: false
-    StellarInertiaTensorReduced: false
-    TotalInertiaTensorNoniterative: general
-    GasInertiaTensorNoniterative: general
-    DarkMatterInertiaTensorNoniterative: general
-    StellarInertiaTensorNoniterative: general
-    TotalInertiaTensorReducedNoniterative: false
-    GasInertiaTensorReducedNoniterative: false
-    DarkMatterInertiaTensorReducedNoniterative: false
-    StellarInertiaTensorReducedNoniterative: false
     StarFormationRate: true
     AveragedStarFormationRate:
       snapshot: true
@@ -439,17 +423,11 @@ SOProperties:
       snapshot: true
       snipshot: false
     GasComptonYTemperature: false
-    GasComptonYTemperatureCoreExcision: false
     GasComptonYTemperatureWithoutRecentAGNHeating: false
-    GasComptonYTemperatureWithoutRecentAGNHeatingCoreExcision: false
     GasTemperature: true
-    GasTemperatureCoreExcision: false
     GasTemperatureWithoutCoolGas: true
     GasTemperatureWithoutCoolGasAndRecentAGNHeating: true
     GasTemperatureWithoutRecentAGNHeating: true
-    GasTemperatureWithoutCoolGasAndRecentAGNHeatingCoreExcision: false
-    GasTemperatureWithoutCoolGasCoreExcision: false
-    GasTemperatureWithoutRecentAGNHeatingCoreExcision: false
     HotGasMass: true
     KineticEnergyGas: general
     KineticEnergyStars: general
@@ -521,31 +499,21 @@ SOProperties:
     XRayLuminosity:
       snapshot: true
       snipshot: false
-    XRayLuminosityCoreExcision: false
     XRayLuminosityWithoutRecentAGNHeating:
       snapshot: true
       snipshot: false
-    XRayLuminosityWithoutRecentAGNHeatingCoreExcision: false
     XRayLuminosityInRestframe: false
-    XRayLuminosityInRestframeCoreExcision: false
     XRayLuminosityInRestframeWithoutRecentAGNHeating: false
-    XRayLuminosityInRestframeWithoutRecentAGNHeatingCoreExcision: false
     XRayPhotonLuminosity:
       snapshot: true
       snipshot: false
-    XRayPhotonLuminosityCoreExcision: false
     XRayPhotonLuminosityWithoutRecentAGNHeating:
       snapshot: true
       snipshot: false
-    XRayPhotonLuminosityWithoutRecentAGNHeatingCoreExcision: false
     XRayPhotonLuminosityInRestframe: false
-    XRayPhotonLuminosityInRestframeCoreExcision: false
     XRayPhotonLuminosityInRestframeWithoutRecentAGNHeating: false
-    XRayPhotonLuminosityInRestframeWithoutRecentAGNHeatingCoreExcision: false
     SpectroscopicLikeTemperature: true
-    SpectroscopicLikeTemperatureCoreExcision: false
     SpectroscopicLikeTemperatureWithoutRecentAGNHeating: true
-    SpectroscopicLikeTemperatureWithoutRecentAGNHeatingCoreExcision: false
     DarkMatterMassFlowRate: general
     ColdGasMassFlowRate: general
     CoolGasMassFlowRate: general


### PR DESCRIPTION
When we check to see if a property listed in the parameter file is valid we just look to see if it's listed in the property table. However, we don't check to see if it is actually defined for the halo type that it's listed under.

Thanks to @VictorForouhar  for spotting this since inertia tensors were listed under ApertureProperties but were not being flagged as invalid.