### PR TITLE
HostHaloIndex points to itself for centrals

### DIFF
--- a/SOAP/property_table.py
+++ b/SOAP/property_table.py
@@ -4215,7 +4215,7 @@ class PropertyTable:
             shape=1,
             dtype=np.int64,
             unit="dimensionless",
-            description="Index (within the SOAP arrays) of the top level parent of this subhalo. -1 for central subhalos.",
+            description="Index (within the SOAP arrays) of the top level parent of this subhalo. -1 for hostless halos.",
             lossy_compression_filter="None",
             dmo_property=True,
             particle_properties=[],


### PR DESCRIPTION
`SOAP/HostHaloIndex` used to have a value of -1 for centrals. This change means that the value for centrals will now be the index of the subhalo itself. Hostless halos still have a value of -1