### PR TITLE
Use different aliases for snipshot

### DIFF
--- a/SOAP/core/snapshot_datasets.py
+++ b/SOAP/core/snapshot_datasets.py
@@ -130,9 +130,7 @@ class SnapshotDatasets:
             SOAP_ptype, SOAP_dset = alias.split("/")
             snap_ptype, snap_dset = aliases[alias].split("/")
             self.dataset_map[alias] = (snap_ptype, snap_dset)
-            if (snap_dset in self.named_columns) and (
-                SOAP_dset not in self.named_columns
-            ):
+            if snap_dset in self.named_columns:
                 self.named_columns[SOAP_dset] = dict(self.named_columns[snap_dset])
 
     def setup_defined_constants(self, defined_constants: Dict):
@@ -182,13 +180,9 @@ class SnapshotDatasets:
         try:
             ptype, dset = self.dataset_map[name]
         except KeyError as e:
-            print(f'Dataset "{name}" not found!')
-            print("The following properties require this dataset:")
-            full_property_list = property_table.PropertyTable.full_property_list
-            for k, v in full_property_list.items():
-                if name in v.particle_properties:
-                    print(f"  {k}")
-            raise e
+            # This should never occur since swift_cells.check_datasets_exist
+            # checks all the properties we require are indeed available
+            raise KeyError(f"Failed to read {name} from input files!")
         return data_dict[ptype][dset]
 
     def get_dataset_column(

--- a/SOAP/core/swift_cells.py
+++ b/SOAP/core/swift_cells.py
@@ -447,6 +447,8 @@ class SWIFTCellGrid:
         # to output a list of properties that require the missing fields
         for ptype in set(self.ptypes).intersection(set(required_datasets.keys())):
             for name in required_datasets[ptype]:
+                # Note that the field names in required_datasets have already had
+                # any aliases applied, so we can check the raw files themselves
                 in_extra = (self.extra_filenames is not None) and (
                     name in self.extra_metadata_combined[ptype]
                 )

--- a/SOAP/particle_selection/SO_properties.py
+++ b/SOAP/particle_selection/SO_properties.py
@@ -3119,7 +3119,7 @@ class SOProperties(HaloProperty):
     Each property should have a corresponding method/property/lazy_property in
     the SOParticleData class above.
     """
-    base_halo_type = 'SOProperties'
+    base_halo_type = "SOProperties"
     property_list = {
         name: PropertyTable.full_property_list[name]
         for name in [

--- a/SOAP/particle_selection/aperture_properties.py
+++ b/SOAP/particle_selection/aperture_properties.py
@@ -3087,7 +3087,7 @@ class ApertureProperties(HaloProperty):
     are bound to the halo.
     """
 
-    base_halo_type = 'ApertureProperties'
+    base_halo_type = "ApertureProperties"
     # Properties to calculate for ApertureProperties. Key is the name of the property.
     # The value indicates the property has a direct dependence on aperture size.
     # This is needed since for larger apertures we sometimes copy across the

--- a/SOAP/particle_selection/projected_aperture_properties.py
+++ b/SOAP/particle_selection/projected_aperture_properties.py
@@ -1413,7 +1413,7 @@ class ProjectedApertureProperties(HaloProperty):
     the halo along the projection axis.
     """
 
-    base_halo_type = 'ProjectedApertureProperties'
+    base_halo_type = "ProjectedApertureProperties"
     # Properties to calculate. The key is the name of the property,
     # the value indicates the property has a direct dependence on aperture size.
     # This is needed since for larger apertures we sometimes copy across the

--- a/SOAP/particle_selection/subhalo_properties.py
+++ b/SOAP/particle_selection/subhalo_properties.py
@@ -1797,7 +1797,7 @@ class SubhaloProperties(HaloProperty):
     Each property should have a corresponding method/property/lazy_property in
     the SubhaloParticleData class above.
     """
-    base_halo_type = 'SubhaloProperties'
+    base_halo_type = "SubhaloProperties"
     property_list = {
         prop: PropertyTable.full_property_list[prop]
         for prop in [

--- a/SOAP/property_table.py
+++ b/SOAP/property_table.py
@@ -4612,7 +4612,8 @@ class DummyProperties:
     category (e.g. we have 'VR/ID' instead of 'ID')
     """
 
-    base_halo_type = 'DummyProperties'
+    base_halo_type = "DummyProperties"
+
     def __init__(self, halo_finder):
         categories = ["SOAP", "Input", halo_finder]
         # Currently FOF properties are only stored for HBT

--- a/parameter_files/COLIBRE_HYBRID.yml
+++ b/parameter_files/COLIBRE_HYBRID.yml
@@ -35,9 +35,7 @@ ApertureProperties:
     AngularMomentumDarkMatter: general
     AngularMomentumGas: general
     AngularMomentumStars: general
-    AtomicHydrogenMass:
-      snapshot: true
-      snipshot: false
+    AtomicHydrogenMass: true
     BlackHolesDynamicalMass: true
     BlackHolesLastEventScalefactor: true
     BlackHolesSubgridMass: true
@@ -122,12 +120,8 @@ ApertureProperties:
     HalfMassRadiusDarkMatter: general
     HalfMassRadiusGas: general
     HalfMassRadiusStars: true
-    HeliumMass:
-      snapshot: true
-      snipshot: false
-    HydrogenMass:
-      snapshot: true
-      snipshot: false
+    HeliumMass: true
+    HydrogenMass: true
     KappaCorotBaryons: general
     KappaCorotGas: general
     KappaCorotStars: general
@@ -191,9 +185,7 @@ ApertureProperties:
       snipshot: false
     LuminosityWeightedMeanStellarAge: true
     MassWeightedMeanStellarAge: true
-    MolecularHydrogenMass:
-      snapshot: true
-      snipshot: false
+    MolecularHydrogenMass: true
     MostMassiveBlackHoleAccretionRate: true
     MostMassiveBlackHoleAveragedAccretionRate: true
     MostMassiveBlackHoleID: true
@@ -293,9 +285,7 @@ ApertureProperties:
       skip_gt_enclose_radius: true
 ProjectedApertureProperties:
   properties:
-    AtomicHydrogenMass:
-      snapshot: true
-      snipshot: false
+    AtomicHydrogenMass: true
     BlackHolesDynamicalMass: true
     BlackHolesLastEventScalefactor: true
     BlackHolesSubgridMass: true
@@ -312,15 +302,9 @@ ProjectedApertureProperties:
     HalfMassRadiusDarkMatter: general
     HalfMassRadiusGas: general
     HalfMassRadiusStars: true
-    HeliumMass:
-      snapshot: true
-      snipshot: false
-    HydrogenMass:
-      snapshot: true
-      snipshot: false
-    MolecularHydrogenMass:
-      snapshot: true
-      snipshot: false
+    HeliumMass: true
+    HydrogenMass: true
+    MolecularHydrogenMass: true
     MostMassiveBlackHoleAccretionRate: true
     MostMassiveBlackHoleAveragedAccretionRate: true
     MostMassiveBlackHoleID: true
@@ -519,12 +503,8 @@ SOProperties:
     CoolGasMassFlowRate: general
     WarmGasMassFlowRate: general
     HotGasMassFlowRate: general
-    HIMassFlowRate:
-      snapshot: general
-      snipshot: false
-    H2MassFlowRate:
-      snapshot: general
-      snipshot: false
+    HIMassFlowRate: general
+    H2MassFlowRate: general
     MetalMassFlowRate: general
     StellarMassFlowRate: general
     ColdGasEnergyFlowRate: general
@@ -658,6 +638,11 @@ SubhaloProperties:
 aliases:
   PartType0/LastSNIIKineticFeedbackDensities: PartType0/DensitiesAtLastSupernovaEvent
   PartType0/LastSNIIThermalFeedbackDensities: PartType0/DensitiesAtLastSupernovaEvent
+  snipshot:
+    PartType0/SpeciesFractions: PartType0/ReducedSpeciesFractions
+    PartType0/ElementMassFractions: PartType0/ReducedElementMassFractions
+    PartType0/LastSNIIKineticFeedbackDensities: PartType0/DensitiesAtLastSupernovaEvent
+    PartType0/LastSNIIThermalFeedbackDensities: PartType0/DensitiesAtLastSupernovaEvent
 filters:
   general:
     limit: 100

--- a/parameter_files/COLIBRE_THERMAL.yml
+++ b/parameter_files/COLIBRE_THERMAL.yml
@@ -35,9 +35,7 @@ ApertureProperties:
     AngularMomentumDarkMatter: general
     AngularMomentumGas: general
     AngularMomentumStars: general
-    AtomicHydrogenMass:
-      snapshot: true
-      snipshot: false
+    AtomicHydrogenMass: true
     BlackHolesDynamicalMass: true
     BlackHolesLastEventScalefactor: true
     BlackHolesSubgridMass: true
@@ -122,12 +120,8 @@ ApertureProperties:
     HalfMassRadiusDarkMatter: general
     HalfMassRadiusGas: general
     HalfMassRadiusStars: true
-    HeliumMass:
-      snapshot: true
-      snipshot: false
-    HydrogenMass:
-      snapshot: true
-      snipshot: false
+    HeliumMass: true
+    HydrogenMass: true
     KappaCorotBaryons: general
     KappaCorotGas: general
     KappaCorotStars: general
@@ -191,9 +185,7 @@ ApertureProperties:
       snipshot: false
     LuminosityWeightedMeanStellarAge: true
     MassWeightedMeanStellarAge: true
-    MolecularHydrogenMass:
-      snapshot: true
-      snipshot: false
+    MolecularHydrogenMass: true
     MostMassiveBlackHoleAccretionRate: true
     MostMassiveBlackHoleAveragedAccretionRate: true
     MostMassiveBlackHoleID: true
@@ -293,9 +285,7 @@ ApertureProperties:
       skip_gt_enclose_radius: true
 ProjectedApertureProperties:
   properties:
-    AtomicHydrogenMass:
-      snapshot: true
-      snipshot: false
+    AtomicHydrogenMass: true
     BlackHolesDynamicalMass: true
     BlackHolesLastEventScalefactor: true
     BlackHolesSubgridMass: true
@@ -312,15 +302,9 @@ ProjectedApertureProperties:
     HalfMassRadiusDarkMatter: general
     HalfMassRadiusGas: general
     HalfMassRadiusStars: true
-    HeliumMass:
-      snapshot: true
-      snipshot: false
-    HydrogenMass:
-      snapshot: true
-      snipshot: false
-    MolecularHydrogenMass:
-      snapshot: true
-      snipshot: false
+    HeliumMass: true
+    HydrogenMass: true
+    MolecularHydrogenMass: true
     MostMassiveBlackHoleAccretionRate: true
     MostMassiveBlackHoleAveragedAccretionRate: true
     MostMassiveBlackHoleID: true
@@ -519,12 +503,8 @@ SOProperties:
     CoolGasMassFlowRate: general
     WarmGasMassFlowRate: general
     HotGasMassFlowRate: general
-    HIMassFlowRate:
-      snapshot: general
-      snipshot: false
-    H2MassFlowRate:
-      snapshot: general
-      snipshot: false
+    HIMassFlowRate: general
+    H2MassFlowRate: general
     MetalMassFlowRate: general
     StellarMassFlowRate: general
     ColdGasEnergyFlowRate: general
@@ -658,6 +638,11 @@ SubhaloProperties:
 aliases:
   PartType0/LastSNIIKineticFeedbackDensities: PartType0/DensitiesAtLastSupernovaEvent
   PartType0/LastSNIIThermalFeedbackDensities: PartType0/DensitiesAtLastSupernovaEvent
+  snipshot:
+    PartType0/SpeciesFractions: PartType0/ReducedSpeciesFractions
+    PartType0/ElementMassFractions: PartType0/ReducedElementMassFractions
+    PartType0/LastSNIIKineticFeedbackDensities: PartType0/DensitiesAtLastSupernovaEvent
+    PartType0/LastSNIIThermalFeedbackDensities: PartType0/DensitiesAtLastSupernovaEvent
 filters:
   general:
     limit: 100

--- a/parameter_files/README.md
+++ b/parameter_files/README.md
@@ -162,14 +162,17 @@ SOProperties:
 
 ### Aliases
 
-Optional. Used if field names in the snapshots do not agree with what SOAP expects, e.g.
+Optional. Used if field names in the snapshots do not agree with what SOAP expects. If the `snipshot` section is passed then those aliases will be used when running in snipshot mode (the snipshot values will not be combined with the snapshot aliases present. If no `snipshot` section is present then the snapshot aliases will be used when running in snipshot mode). E.g.
 ```
 aliases:
   PartType0/ElementMassFractions: PartType0/SmoothedElementMassFractions
   PartType4/ElementMassFractions: PartType4/SmoothedElementMassFractions
+  snipshot:
+    PartType0/ElementMassFractions: PartType0/ReducedElementMassFractions
+    PartType4/ElementMassFractions: PartType4/SmoothedElementMassFractions
+
 ```
-The key is the name of the property that SOAP expects, and the value is the name
-of the property in the snapshot being passed.
+For each alias the key is the name of the property that SOAP expects, and the value is the name of the property in the snapshot being passed.
 
 ### Filters
 


### PR DESCRIPTION
For COLIBRE we don't output full `ElementMassFractions` and `SpeciesFractions` for snipshots, but instead output  `ReducedElementMassFractions` and `ReducedSpeciesFractions`. This PR allows the user to pass a different set of aliases for snipshots than for snapshots, which means we can make use of these Reduced fields.