### PR TITLE
New Inclsuive aperture definition

### DIFF
--- a/SOAP/particle_selection/aperture_properties.py
+++ b/SOAP/particle_selection/aperture_properties.py
@@ -3304,7 +3304,7 @@ class ApertureProperties(HaloProperty):
                 self.group_name = f"InclusiveSphere/{self.physical_radius_mpc*1000.:.0f}kpc"
             else:
                 self.name = f"inclusive_sphere_renclose"
-                self.group_name = f"InclusiveSphere/REnclose"
+                self.group_name = f"InclusiveSphere/EncloseRadius"
             # TODO: Will this work with swiftsimio
         else:
             assert self.physical_radius_mpc != 0

--- a/parameter_files/COLIBRE_THERMAL.yml
+++ b/parameter_files/COLIBRE_THERMAL.yml
@@ -259,6 +259,9 @@ ApertureProperties:
     exclusive_100_kpc:
       inclusive: false
       radius_in_kpc: 100.0
+    inclusive_r_enclose:
+      inclusive: true
+      radius_in_kpc: 0.0
     inclusive_1_kpc:
       inclusive: true
       radius_in_kpc: 1.0

--- a/parameter_files/README.md
+++ b/parameter_files/README.md
@@ -92,6 +92,7 @@ ApertureProperties:
       skip_gt_enclose_radius: false
 ```
 
+# TODO: Note that inclusive can be passed encloseradius
 If you do not wish to calculate any apertures then pass any empty dict to both the properties and the variations, e.g.
 
 ```


### PR DESCRIPTION
Joop has asked for a new aperture definition to be added. This is basically an exclusive aperture, but for each satellite subhalo any particles bound to it's hosts central subhalo should also be included.

I'm also adding an `InclusiveSphere/EncloseRadius` option.