### PR TITLE
Calculate fof extent

### DIFF
--- a/SOAP/core/soap_args.py
+++ b/SOAP/core/soap_args.py
@@ -122,6 +122,7 @@ def get_soap_args(comm):
     args.halo_basename = all_args["HaloFinder"]["filename"]
     args.halo_format = all_args["HaloFinder"]["type"]
     args.fof_group_filename = all_args["HaloFinder"].get("fof_filename", "")
+    args.fof_radius_filename = all_args["HaloFinder"].get("fof_radius_filename", "")
     args.output_file = all_args["HaloProperties"]["filename"]
     args.snapshot_nr = all_args["Parameters"]["snap_nr"]
     args.chunks = all_args["Parameters"]["chunks"]
@@ -178,6 +179,14 @@ def get_soap_args(comm):
             )
             if not os.path.exists(fof_filename):
                 print(f"Could not find FOF group catalogue: {fof_filename}")
+                comm.Abort(1)
+        if args.fof_radius_filename != "":
+            assert args.fof_group_filename != ""
+            fof_filename = args.fof_radius_filename.format(
+                snap_nr=args.snapshot_nr, file_nr=0
+            )
+            if not os.path.exists(fof_filename):
+                print(f"Could not find FOF radius catalogue: {fof_filename}")
                 comm.Abort(1)
 
     return args

--- a/SOAP/property_table.py
+++ b/SOAP/property_table.py
@@ -4232,6 +4232,18 @@ class PropertyTable:
             output_physical=True,
             a_scale_exponent=None,
         ),
+        "FOF/Radii": Property(
+            name="FOF/Radii",
+            shape=1,
+            dtype=np.float32,
+            unit="snap_length",
+            description="Radius of the particle furthest from the FOF centre of mass. Zero for satellite and hostless subhalos. Missing for older runs.",
+            lossy_compression_filter="FMantissa9",
+            dmo_property=True,
+            particle_properties=[],
+            output_physical=False,
+            a_scale_exponent=1,
+        ),
         # SOAP properties
         "SOAP/SubhaloRankByBoundMass": Property(
             name="SOAP/SubhaloRankByBoundMass",
@@ -4484,8 +4496,8 @@ Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category & Compression\\\
             prop = self.properties[prop_name]
             footnotes = self.get_footnotes(prop_name)
             prop_outputname = f"{prop['name']}{footnotes}"
-            if prop_outputname.split('/')[0] in ['HBTplus', 'VR', 'FOF']:
-                prop_outputname = 'InputHalos/' + prop_outputname
+            if prop_outputname.split("/")[0] in ["HBTplus", "VR", "FOF"]:
+                prop_outputname = "InputHalos/" + prop_outputname
             prop_outputname = word_wrap_name(prop_outputname)
             prop_shape = f'{prop["shape"]}'
             prop_dtype = prop["dtype"]

--- a/misc/calculate_fof_positions.py
+++ b/misc/calculate_fof_positions.py
@@ -169,15 +169,6 @@ for ptype in ptypes:
     part_pos = part_pos[mask]
     part_fof_ids = part_fof_ids[mask]
 
-    # Get the centre of the FOF each particle is part of
-    idx = psort.parallel_match(part_fof_ids, fof_group_ids, comm=comm)
-    assert np.all(idx != -1), "FOFs could not be found for some particles"
-    part_centre = psort.fetch_elements(fof_centres, idx, comm=comm)
-
-    # Centre the particles
-    shift = (boxsize[None, :] / 2) - part_centre
-    part_pos = ((part_pos + shift) % boxsize[None, :]) - (boxsize[None, :] / 2)
-
     # Count the number of particles found for each FOF
     unique_fof_ids, unique_counts = psort.parallel_unique(
         part_fof_ids,
@@ -243,8 +234,8 @@ for ptype in ptypes:
 
 # Carry out some sanity checks
 assert np.all(total_part_counts == fof_sizes), "Not all particles found for some FOFs"
-assert np.max(fof_min_pos) < 0
-assert np.min(fof_max_pos) > 0
+assert np.max(fof_min_pos) < np.inf
+assert np.min(fof_max_pos) > -np.inf
 
 # Write data to file
 output_data = {

--- a/misc/calculate_fof_positions.py
+++ b/misc/calculate_fof_positions.py
@@ -169,6 +169,16 @@ for ptype in ptypes:
     part_pos = part_pos[mask]
     part_fof_ids = part_fof_ids[mask]
 
+    # Get the centre of the FOF each particle is part of
+    idx = psort.parallel_match(part_fof_ids, fof_group_ids, comm=comm)
+    assert np.all(idx != -1), "FOFs could not be found for some particles"
+    part_centre = psort.fetch_elements(fof_centres, idx, comm=comm)
+
+    # Move particles outside the box if required
+    shift = (boxsize[None, :] / 2) - part_centre
+    part_pos = (part_pos + shift) % boxsize[None, :]
+    part_pos -= shift
+
     # Count the number of particles found for each FOF
     unique_fof_ids, unique_counts = psort.parallel_unique(
         part_fof_ids,

--- a/misc/calculate_fof_positions.py
+++ b/misc/calculate_fof_positions.py
@@ -1,27 +1,19 @@
 #!/bin/env python
 
 """
+calculate_fof_positions.py
 
-mpirun -np 8 python -u misc/fof_prop.py \
-    --snap-basename "${sim_dir}/snapshots/colibre_${snap_nr}/colibre_${snap_nr}" \
-    --fof-basename "${sim_dir}/fof/fof_output_${snap_nr}/fof_output_${snap_nr}" \
-    --output-basename "${output_dir}/${sim_name}/fof_extent_${snap_nr}/fof_extent_${snap_nr}"
-TODO: WRITE DOCSTRING
-convert_eagle.py
-
-This script converts EAGLE GADGET snapshots into SWIFT snapshots.
+This script calculates the maximum and minimum particles positions for each FOF.
 Usage:
 
-  mpirun -- python convert_eagle.py \
+  mpirun -- python misc/calculate_fof_positions.py \
           --snapshot-basename=SNAPSHOT \
           --fof-basename=FOF \
-          --output-basename=OUTPUT \
-          --membership-basename=MEMBERSHIP
+          --output-basename=OUTPUT
 
-where SNAPSHOT is the EAGLE snapshot (use the particledata_*** files,
-since the normal snapshots don't store SubGroupNumber), and OUTPUT &
-MEMBERSHIP are the names of the output files. You must run with
-the same number of ranks as input files.
+where SNAPSHOT is the basename of the snapshot files (the snapshot
+name without the .{file_nr}.hdf5 suffix), FOF is the basename of the
+fof catalogues, and OUTPUT is the basename of the output fof catalogues.
 """
 
 import argparse
@@ -260,6 +252,8 @@ fof_file.write(
     group="Groups",
     attrs=coordinate_unit_attrs,
 )
+
+# TODO: Create virtual files
 
 if comm_rank == 0:
     print('Done')

--- a/misc/calculate_fof_positions.py
+++ b/misc/calculate_fof_positions.py
@@ -130,7 +130,8 @@ for i_file in range(
     src_filename = fof_filename.format(file_nr=i_file)
     dst_filename = output_filename.format(file_nr=i_file)
     with h5py.File(src_filename, "r") as src_file, h5py.File(dst_filename, "w") as dst_file:
-        copy_object(src_file, dst_file, src_filename)
+        rel_filename = os.path.relpath(src_filename, os.path.dirname(dst_filename))
+        copy_object(src_file, dst_file, rel_filename)
 
 # Load FOF catalogue
 fof_file = phdf5.MultiFile(
@@ -283,9 +284,10 @@ if comm_rank == 0:
             offset = 0
             for i_file in range(nr_files):
                 src_filename = output_filename.format(file_nr=i_file)
+                rel_filename = os.path.relpath(src_filename, os.path.dirname(dst_filename))
                 count = counts[i_file]
                 layout[offset : offset + count] = h5py.VirtualSource(
-                    src_filename, f"Groups/{prop}", shape=(count, *shape[1:])
+                    rel_filename, f"Groups/{prop}", shape=(count, *shape[1:])
                 )
                 offset += count
             dst_file.create_virtual_dataset(

--- a/misc/fof_prop.py
+++ b/misc/fof_prop.py
@@ -1,0 +1,253 @@
+#!/bin/env python
+
+"""
+TODO: WRITE DOCSTRING
+convert_eagle.py
+
+This script converts EAGLE GADGET snapshots into SWIFT snapshots.
+Usage:
+
+  mpirun -- python convert_eagle.py \
+          --snapshot-basename=SNAPSHOT \
+          --fof-basename=FOF \
+          --output-basename=OUTPUT \
+          --membership-basename=MEMBERSHIP
+
+where SNAPSHOT is the EAGLE snapshot (use the particledata_*** files,
+since the normal snapshots don't store SubGroupNumber), and OUTPUT &
+MEMBERSHIP are the names of the output files. You must run with
+the same number of ranks as input files.
+"""
+
+import argparse
+import os
+
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+comm_rank = comm.Get_rank()
+comm_size = comm.Get_size()
+
+import h5py
+import numpy as np
+import unyt
+
+import virgo.mpi.parallel_sort as psort
+import virgo.mpi.parallel_hdf5 as phdf5
+from virgo.mpi.gather_array import gather_array
+
+# Parse arguments
+parser = argparse.ArgumentParser(
+    description=(
+        "Script to calculate extent of FoF groups."
+    )
+)
+parser.add_argument(
+    "--snap-basename",
+    type=str,
+    required=True,
+    help=(
+        "The basename for the snapshot files (the snapshot "
+        "name without the .{file_nr}.hdf5 suffix)"
+    ),
+)
+parser.add_argument(
+    "--fof-basename",
+    type=str,
+    required=True,
+    help="The basename for the output files",
+)
+parser.add_argument(
+    "--output-basename",
+    type=str,
+    required=True,
+    help=(
+        "The basename for the output files"
+    ),
+)
+parser.add_argument(
+    "--null-fof-id",
+    type=int,
+    required=False,
+    default=2147483647,
+    help=(
+        "The FOFGroupIDs of particles not in a FOF group"
+    ),
+)
+args = parser.parse_args()
+snap_filename = args.snap_basename + ".{file_nr}.hdf5"
+fof_filename = args.fof_basename + ".{file_nr}.hdf5"
+output_filename = args.output_basename + ".{file_nr}.hdf5"
+os.makedirs(os.path.dirname(output_filename), exist_ok=True)
+
+if comm_rank == 0:
+    with h5py.File(snap_filename.format(file_nr=0), "r") as file:
+        header = file['Header'].attrs
+        boxsize = header['BoxSize']
+        ptypes = np.where(header['TotalNumberOfParticles'] != 0)[0]
+        coordinate_unit_attrs = dict(file['PartType1/Coordinates'].attrs)
+
+
+    # TODO: Split across ranks
+    for i_file in range(4):
+        src_filename = fof_filename.format(file_nr=i_file)
+        dst_filename = output_filename.format(file_nr=i_file)
+
+        def copy_attrs(src_obj, dst_obj):
+            for key, val in src_obj.attrs.items():
+                dst_obj.attrs[key] = val
+
+        with h5py.File(src_filename, "r") as src_file, h5py.File(dst_filename, "w") as dst_file:
+
+            def create_virtual_datasets(src_group, dst_group, src_filename, prefix=""):
+                copy_attrs(src_group, dst_group)
+
+                for name, item in src_group.items():
+                    if isinstance(item, h5py.Dataset):
+                        shape = item.shape
+                        dtype = item.dtype
+                        layout = h5py.VirtualLayout(shape=shape, dtype=dtype)
+                        vsource = h5py.VirtualSource(src_filename, prefix + name, shape=shape)
+                        layout[...] = vsource
+                        vds = dst_group.create_virtual_dataset(name, layout)
+                        copy_attrs(item, vds)  # Copy dataset attributes
+                    elif isinstance(item, h5py.Group):
+                        new_group = dst_group.create_group(name)
+                        create_virtual_datasets(item, new_group, src_filename, prefix + name + "/")
+
+            create_virtual_datasets(src_file, dst_file, src_filename)
+
+        print("Virtual copy with attributes created successfully.")
+
+
+else:
+    boxsize = None
+    ptypes = None
+    coordinate_unit_attrs = None
+boxsize = comm.bcast(boxsize)
+ptypes = comm.bcast(ptypes)
+coordinate_unit_attrs = comm.bcast(coordinate_unit_attrs)
+
+# Load FOF catalogue
+fof_file = phdf5.MultiFile(
+    fof_filename, file_nr_attr=("Header", "NumFilesPerSnapshot"), comm=comm
+)
+fof_group_ids = fof_file.read(f"Groups/GroupIDs")
+fof_sizes = fof_file.read(f"Groups/Sizes")
+fof_centres = fof_file.read(f"Groups/Centres")
+
+# Initialise arrays for storing results
+fof_min_pos = np.inf * np.ones_like(fof_centres)
+fof_max_pos = -np.inf * np.ones_like(fof_centres)
+total_part_counts = np.zeros_like(fof_sizes)
+
+# Open snapshot file
+snap_file = phdf5.MultiFile(
+    snap_filename, file_nr_attr=("Header", "NumFilesPerSnapshot"), comm=comm
+)
+for ptype in ptypes:
+    if comm_rank == 0:
+        print(f'Processing PartType{ptype}')
+
+    # Load particle positions and their FOF IDs
+    part_pos = snap_file.read(f"PartType{ptype}/Coordinates")
+    part_fof_ids = snap_file.read(f"PartType{ptype}/FOFGroupIDs")
+
+    # Ignore particles which aren't part of a FOF group
+    mask = part_fof_ids != args.null_fof_id
+    part_pos = part_pos[mask]
+    part_fof_ids = part_fof_ids[mask]
+
+    # Get the centre of the FOF each particle is part of
+    idx = psort.parallel_match(part_fof_ids, fof_group_ids, comm=comm)
+    assert np.all(idx != -1), 'FOFs could not be found for some particles'
+    part_centre = psort.fetch_elements(fof_centres, idx, comm=comm)
+
+    # Centre the particles
+    shift = (boxsize[None, :] / 2) - part_centre
+    part_pos = ((part_pos + shift) % boxsize[None, :]) - (boxsize[None, :] / 2)
+
+    # Count the number of particles found for each FOF
+    unique_fof_ids, unique_counts = psort.parallel_unique(
+        part_fof_ids,
+        return_counts=True,
+        comm=comm,
+    )
+
+    # Keep track of number of particles in each FOF (to compare with "Groups/Sizes")
+    idx = psort.parallel_match(fof_group_ids, unique_fof_ids, comm=comm)
+    mask = idx != -1
+    total_part_counts[mask] += psort.fetch_elements(unique_counts, idx[mask], comm=comm)
+
+    # Sort based on unique_fof_ids
+    order = psort.parallel_sort(unique_fof_ids, return_index=True, comm=comm)
+    unique_counts = psort.fetch_elements(unique_counts, order, comm=comm)
+
+    # Determine how to partition the particles, so groups will not span ranks
+    gathered_counts = gather_array(unique_counts)
+    if comm_rank == 0:
+        n_part_target = np.sum(gathered_counts) / comm_size
+        cumsum = np.cumsum(gathered_counts)
+        ranks = np.floor(cumsum / n_part_target).astype(int)
+        ranks = np.clip(ranks, 0, comm_size-1)
+        n_part_per_rank = np.bincount(ranks, weights=gathered_counts, minlength=comm_size)
+        assert np.sum(n_part_per_rank) == np.sum(gathered_counts)
+    else:
+        n_part_per_rank = None
+    del gathered_counts
+    n_part_per_rank = comm.bcast(n_part_per_rank)
+
+    # Repartition particle data
+    part_fof_ids = psort.repartition(part_fof_ids, n_part_per_rank, comm=comm)
+    part_pos = psort.repartition(part_pos, n_part_per_rank, comm=comm)
+
+    # Sort particles by FOF ID
+    order = psort.parallel_sort(part_fof_ids, return_index=True, comm=comm)
+    part_pos = psort.fetch_elements(part_pos, order, comm=comm)
+
+    # Find boundaries where FOF ID changes
+    if part_fof_ids.shape[0] != 0:
+        change_idx = np.flatnonzero(np.diff(part_fof_ids)) + 1
+        reduce_idx = np.concatenate([np.array([0]), change_idx])
+    else:
+        reduce_idx = np.array([], dtype=int)
+
+    # Determine link to arrays from original FOF catalogue
+    local_fof_ids = part_fof_ids[reduce_idx]
+    idx = psort.parallel_match(fof_group_ids, local_fof_ids, comm=comm)
+    mask = idx != -1
+
+    for i in range(3):
+        # Calculate max and minimum particle positions for each FOF ID
+        local_min_pos = np.minimum.reduceat(part_pos[:, i], reduce_idx)
+        local_max_pos = np.maximum.reduceat(part_pos[:, i], reduce_idx)
+
+        # Compare with values from other particle types
+        min_pos = psort.fetch_elements(local_min_pos, idx[mask], comm=comm)
+        max_pos = psort.fetch_elements(local_max_pos, idx[mask], comm=comm)
+        fof_min_pos[mask, i] = np.minimum(fof_min_pos[mask, i], min_pos)
+        fof_max_pos[mask, i] = np.maximum(fof_max_pos[mask, i], max_pos)
+
+# Carry out some sanity checks
+assert np.all(total_part_counts == fof_sizes), 'Not all particles found for some FOFs'
+assert np.max(fof_min_pos) < 0
+assert np.min(fof_max_pos) > 0
+
+# Write data to file
+output_data = {
+    "MinParticlePosition": fof_min_pos,
+    "MaxParticlePosition": fof_max_pos,
+}
+elements_per_file = fof_file.get_elements_per_file("Groups/GroupIDs")
+fof_file.write(
+    output_data,
+    elements_per_file,
+    filenames=output_filename,
+    mode='r+',
+    group="Groups",
+    attrs=coordinate_unit_attrs,
+)
+
+if comm_rank == 0:
+    print('Done')
+

--- a/misc/test_fof_positions.py
+++ b/misc/test_fof_positions.py
@@ -47,8 +47,8 @@ args = parser.parse_args()
 
 # Load the FOF file
 fof = sw.load(args.fof_filename)
-min_pos = fof.fof_groups.min_particle_position
-max_pos = fof.fof_groups.max_particle_position
+min_pos = fof.fof_groups.centres - fof.fof_groups.radii[:, None]
+max_pos = fof.fof_groups.centres + fof.fof_groups.radii[:, None]
 
 n_test = args.n_test if args.n_test != -1 else fof.fof_groups.sizes.shape[0]
 for i_fof in tqdm.tqdm(range(n_test)):

--- a/misc/test_fof_positions.py
+++ b/misc/test_fof_positions.py
@@ -1,0 +1,72 @@
+#!/bin/env python
+
+"""
+test_fof_positions.py
+
+This script tests the output of calculate_fof_positions.py.
+Usage:
+
+  python misc/calculate_fof_positions.py \
+      --snap-filename=SNAPSHOT \
+      --fof-filename=FOF
+
+where SNAPSHOT is the filename of the virtual snapshot file,
+and FOF is the filename of the virtual FOF cataloge file.
+"""
+
+import argparse
+
+import numpy as np
+import swiftsimio as sw
+import tqdm
+
+# Parse arguments
+parser = argparse.ArgumentParser(
+    description="Script to calculate extent of FoF groups."
+)
+parser.add_argument(
+    "--snap-filename",
+    type=str,
+    required=True,
+    help="The filename of the virtual snapshot file",
+)
+parser.add_argument(
+    "--fof-filename",
+    type=str,
+    required=True,
+    help="The filename of the virtual FOF catalogue file",
+)
+parser.add_argument(
+    "--n-test",
+    type=int,
+    required=False,
+    default=-1,
+    help="The number of FOFs to check. If -1 all objects will be checked",
+)
+args = parser.parse_args()
+
+# Load the FOF file
+fof = sw.load(args.fof_filename)
+min_pos = fof.fof_groups.centres + fof.fof_groups.min_particle_position
+max_pos = fof.fof_groups.centres + fof.fof_groups.max_particle_position
+
+n_test = args.n_test if args.n_test != -1 else fof.fof_groups.sizes.shape[0]
+for i_fof in tqdm.tqdm(range(n_test)):
+
+    # Create mask and load data
+    mask = sw.mask(args.snap_filename)
+    load_region = [
+        [min_pos[i_fof, 0], max_pos[i_fof, 0]],
+        [min_pos[i_fof, 1], max_pos[i_fof, 1]],
+        [min_pos[i_fof, 2], max_pos[i_fof, 2]],
+    ]
+    mask.constrain_spatial(load_region)
+    snap = sw.load(args.snap_filename, mask=mask)
+
+    # Check we loaded all the particles
+    n_total = 0
+    for ptype in ["gas", "dark_matter", "stars", "black_holes"]:
+        fof_id = fof.fof_groups.group_ids[i_fof].value
+        part_fof_ids = getattr(snap, ptype).fofgroup_ids.value
+        n_total += np.sum(part_fof_ids == fof_id)
+    assert n_total == fof.fof_groups.sizes[i_fof].value, f"Failed for object {i_fof}"

--- a/misc/test_fof_positions.py
+++ b/misc/test_fof_positions.py
@@ -47,8 +47,8 @@ args = parser.parse_args()
 
 # Load the FOF file
 fof = sw.load(args.fof_filename)
-min_pos = fof.fof_groups.centres + fof.fof_groups.min_particle_position
-max_pos = fof.fof_groups.centres + fof.fof_groups.max_particle_position
+min_pos = fof.fof_groups.min_particle_position
+max_pos = fof.fof_groups.max_particle_position
 
 n_test = args.n_test if args.n_test != -1 else fof.fof_groups.sizes.shape[0]
 for i_fof in tqdm.tqdm(range(n_test)):

--- a/parameter_files/README.md
+++ b/parameter_files/README.md
@@ -38,6 +38,7 @@ Settings for the halo finding algorithm and output file locations.
 - **type**: The subhalo finder being used. Possible options are `HBTplus`, `VR`, `Subfind`, and `Rockstar`.
 - **filename**: Template for input halo catalogue files. The format of this depends on the halo finder as they have different output structure. HBTplus example: `"{sim_dir}/{sim_name}/HBT/{snap_nr:03d}/SubSnap_{snap_nr:03d}"`
 - **fof_filename**: Template for FOF catalog files. Used for storing host FOF information for central subhalos. This is currently only supported for HBTplus
+- **fof_radius_filename**: Template for FOF catalog files which contain the "Groups/Radii" dataset. These were produced by a post-processing script, and are missing from the main FOFs
 
 ### Group Membership
 


### PR DESCRIPTION
When SWIFT outputs FOF catalogues it does not give any information about the size (the distance to the furthest particles in each group). This PR adds a script which calculates the maximum/minimum x,y,z coordinates of the particles within each FOF group. 

The output is a FOF catalogue with the same format as the SWIFT ones, except with two extra fields: `MinParticlePosition` & `MinParticlePosition`. ~~These contain the maximum/minimum x.y,z particle position **relative** to the FOF centre.~~ These contain the absolute position of the maximum/minimum x,y,z particle positions, but particle have been moved outside the box to be as close to the FOF centre as possible (e..g a particle with x=0.99 which is part of a FOF with a centre at x=0.01 will be moved to x=-0.01). The new FOF catalogue links to the old catalogue for all other fields (e.g. `Masses`), this information is not copied.

**TODO**
- [x] Decide if we want to store relative or absolute particle positions (currently relative)
- [x] Update SOAP to read this information
- [x] Test efficiency on a big run