### PR TITLE
Add half-light radii for each GAMA band.

### DIFF
--- a/SOAP/particle_selection/aperture_properties.py
+++ b/SOAP/particle_selection/aperture_properties.py
@@ -141,7 +141,7 @@ import unyt
 
 from .halo_properties import HaloProperty, SearchRadiusTooSmallError
 from SOAP.core.dataset_names import mass_dataset
-from SOAP.property_calculation.half_mass_radius import get_half_mass_radius
+from SOAP.property_calculation.half_mass_radius import get_half_mass_radius, get_half_light_radius
 from SOAP.property_calculation.kinematic_properties import (
     get_velocity_dispersion_matrix,
     get_angular_momentum,
@@ -3175,6 +3175,15 @@ class ApertureParticleData:
         """
         return get_half_mass_radius(
             self.radius[self.type == 4], self.mass_star, self.Mstar
+        )
+
+    @lazy_property
+    def HalfLightRadiusStar(self) -> unyt.unyt_array:
+        """
+        Half light radius of stars for the 9 GAMA bands.
+        """
+        return get_half_light_radius(
+            self.radius[self.type == 4], self.stellar_luminosities, self.StellarLuminosity
         )
 
     @lazy_property

--- a/SOAP/particle_selection/aperture_properties.py
+++ b/SOAP/particle_selection/aperture_properties.py
@@ -3281,6 +3281,7 @@ class ApertureProperties(HaloProperty):
         "HalfMassRadiusDust": False,
         "HalfMassRadiusDM": False,
         "HalfMassRadiusStar": False,
+        "HalfLightRadiusStar": False,
         "HalfMassRadiusBaryon": False,
         "DtoTgas": False,
         "DtoTstar": False,

--- a/SOAP/particle_selection/projected_aperture_properties.py
+++ b/SOAP/particle_selection/projected_aperture_properties.py
@@ -1501,6 +1501,7 @@ class ProjectedApertureProperties(HaloProperty):
         "HalfMassRadiusDust": False,
         "HalfMassRadiusDM": False,
         "HalfMassRadiusStar": False,
+        "HalfLightRadiusStar": False,
         "HalfMassRadiusBaryon": False,
         "proj_veldisp_gas": False,
         "proj_veldisp_dm": False,

--- a/SOAP/particle_selection/projected_aperture_properties.py
+++ b/SOAP/particle_selection/projected_aperture_properties.py
@@ -33,7 +33,7 @@ from SOAP.core.category_filter import CategoryFilter
 from SOAP.core.parameter_file import ParameterFile
 from SOAP.core.snapshot_datasets import SnapshotDatasets
 from SOAP.core.dataset_names import mass_dataset
-from SOAP.property_calculation.half_mass_radius import get_half_mass_radius
+from SOAP.property_calculation.half_mass_radius import get_half_mass_radius, get_half_light_radius
 from SOAP.property_table import PropertyTable
 from SOAP.property_calculation.kinematic_properties import get_projected_inertia_tensor
 
@@ -1439,6 +1439,15 @@ class SingleProjectionProjectedApertureParticleData:
         """
         return get_half_mass_radius(
             self.proj_radius[self.proj_type == 4], self.proj_mass_star, self.Mstar
+        )
+
+    @lazy_property
+    def HalfLightRadiusStar(self) -> unyt.unyt_array:
+        """
+        Half light radius of stars for the 9 GAMA bands.
+        """
+        return get_half_light_radius(
+            self.proj_radius[self.proj_type == 4], self.stellar_luminosities, self.StellarLuminosity
         )
 
     @lazy_property

--- a/SOAP/particle_selection/subhalo_properties.py
+++ b/SOAP/particle_selection/subhalo_properties.py
@@ -23,7 +23,7 @@ from numpy.typing import NDArray
 import unyt
 
 from .halo_properties import HaloProperty, SearchRadiusTooSmallError
-from SOAP.property_calculation.half_mass_radius import get_half_mass_radius
+from SOAP.property_calculation.half_mass_radius import get_half_mass_radius, get_half_light_radius
 from SOAP.property_calculation.kinematic_properties import (
     get_angular_momentum,
     get_angular_momentum_and_kappa_corot,
@@ -1810,6 +1810,16 @@ class SubhaloParticleData:
         )
 
     @lazy_property
+    def HalfLightRadiusStar(self) -> unyt.unyt_array:
+        """
+        Half-light radius of the star particle distribution in the subhalo, for
+        the 9 GAMA bands.
+        """
+        return get_half_light_radius(
+            self.radius[self.star_mask_sh], self.stellar_luminosities, self.StellarLuminosity
+        )
+
+    @lazy_property
     def HalfMassRadiusBaryon(self) -> unyt.unyt_quantity:
         """
         Half-mass radius of the baryon (gas + star) particle distribution in the
@@ -1915,6 +1925,7 @@ class SubhaloProperties(HaloProperty):
             "HalfMassRadiusGas",
             "HalfMassRadiusDM",
             "HalfMassRadiusStar",
+            "HalfLightRadiusStar",
             "HalfMassRadiusBaryon",
             "GasInertiaTensor",
             "DarkMatterInertiaTensor",

--- a/SOAP/property_calculation/half_mass_radius.py
+++ b/SOAP/property_calculation/half_mass_radius.py
@@ -12,6 +12,86 @@ We put this in a separate file to facilitate unit testing.
 import numpy as np
 import unyt
 
+def get_half_weight_radius(
+    radius: unyt.unyt_array, weights: unyt.unyt_array, total_weight: unyt.unyt_quantity
+) -> unyt.unyt_quantity:
+    """
+    Get the radius that encloses half of the total weight of the given particle distribution.
+
+    We obtain the half weight radius by sorting the particles on radius and then computing
+    the cumulative weight profile from this. We then determine in which "bin" the cumulative
+    weight profile intersects the target half weight value and obtain the corresponding
+    radius from linear interpolation.
+
+    Parameters:
+     - radius: unyt.unyt_array
+       Radii of the particles.
+     - weight: unyt.unyt_array
+       Weight of individual particles.
+     - total_weight: unyt.unyt_quantity
+       Total weight of the particles. Should be weights.sum(). We pass this on as an argument
+       because this value might already have been computed before. If it was not, then
+       computing it in the function call is still an efficient way to do this.
+
+    Returns the radius that encloses half of the summed weight, defined as the radius 
+    at which the cumulative weight profile reaches 0.5 * total_weight.
+    """
+    if total_weight == 0.0 * total_weight.units or len(weights) < 1:
+        return 0.0 * radius.units
+
+    target_weight = 0.5 * total_weight
+
+    isort = np.argsort(radius)
+    sorted_radius = radius[isort]
+
+    # Compute sum in double precision to avoid numerical overflow due to
+    # weird unit conversions in unyt
+    cumulative_weights = weights[isort].cumsum(dtype=np.float64)
+
+    # Consistency check.
+    # np.sum() and np.cumsum() use different orders, so we have to allow for
+    # some small difference.
+    if cumulative_weights[-1] < 0.999 * total_weight:
+        raise RuntimeError(
+            "Weights sum up to less than the given total weight value:"
+            f" cumulative_weights[-1] = {cumulative_weights[-1]},"
+            f" total_weights = {total_weight}!"
+        )
+
+    # Find the intersection point, abd if that is the first bin, set the lower limits to 0.
+    ihalf = np.argmax(cumulative_weights >= target_weight)
+    if ihalf == 0:
+        rmin = 0.0 * radius.units
+        WeightMin = 0.0 * weights.units
+    else:
+        rmin = sorted_radius[ihalf - 1]
+        WeightMin = cumulative_weights[ihalf - 1]
+    rmax = sorted_radius[ihalf]
+    WeightMax = cumulative_weights[ihalf]
+
+    # Now get the radius by linearly interpolating. If the bin edges coincide 
+    # (two particles at exactly the same radius) then we simply take that radius
+    if WeightMin == WeightMax:
+        half_weight_radius = 0.5 * (rmin + rmax)
+    else:
+        half_weight_radius = rmin + (target_weight - WeightMin) / (WeightMax - WeightMin) * (rmax - rmin)
+
+    # Consistency check.
+    # We cannot use '>=', since equality would happen if half_mass_radius == 0.
+    if half_weight_radius > sorted_radius[-1]:
+        raise RuntimeError(
+            "Half weight radius larger than input radii:"
+            f" half_mass_radius = {half_weight_radius},"
+            f" sorted_radius[-1] = {sorted_radius[-1]}!"
+            f" ihalf = {ihalf}, Npart = {len(radius)},"
+            f" target_weight = {target_weight},"
+            f" rmin = {rmin}, rmax = {rmax},"
+            f" WeightMin = {WeightMin}, WeightMax = {WeightMax},"
+            f" sorted_radius = {sorted_radius},"
+            f" cumulative_weights = {cumulative_weights}"
+        )
+
+    return half_weight_radius
 
 def get_half_mass_radius(
     radius: unyt.unyt_array, mass: unyt.unyt_array, total_mass: unyt.unyt_quantity
@@ -35,65 +115,9 @@ def get_half_mass_radius(
        computing it in the function call is still an efficient way to do this.
 
     Returns the half mass radius, defined as the radius at which the cumulative mass profile
-    reaches 0.5*total_mass.
+    reaches 0.5 * total_mass.
     """
-    if total_mass == 0.0 * total_mass.units or len(mass) < 1:
-        return 0.0 * radius.units
-
-    target_mass = 0.5 * total_mass
-
-    isort = np.argsort(radius)
-    sorted_radius = radius[isort]
-    # compute sum in double precision to avoid numerical overflow due to
-    # weird unit conversions in unyt
-    cumulative_mass = mass[isort].cumsum(dtype=np.float64)
-
-    # consistency check
-    # np.sum() and np.cumsum() use different orders, so we have to allow for
-    # some small difference
-    if cumulative_mass[-1] < 0.999 * total_mass:
-        raise RuntimeError(
-            "Masses sum up to less than the given total mass:"
-            f" cumulative_mass[-1] = {cumulative_mass[-1]},"
-            f" total_mass = {total_mass}!"
-        )
-
-    # find the intersection point
-    # if that is the first bin, set the lower limits to 0
-    ihalf = np.argmax(cumulative_mass >= target_mass)
-    if ihalf == 0:
-        rmin = 0.0 * radius.units
-        Mmin = 0.0 * mass.units
-    else:
-        rmin = sorted_radius[ihalf - 1]
-        Mmin = cumulative_mass[ihalf - 1]
-    rmax = sorted_radius[ihalf]
-    Mmax = cumulative_mass[ihalf]
-
-    # now get the radius by linearly interpolating
-    # if the bin edges coincide (two particles at exactly the same radius)
-    # then we simply take that radius
-    if Mmin == Mmax:
-        half_mass_radius = 0.5 * (rmin + rmax)
-    else:
-        half_mass_radius = rmin + (target_mass - Mmin) / (Mmax - Mmin) * (rmax - rmin)
-
-    # consistency check
-    # we cannot use '>=', since equality would happen if half_mass_radius==0
-    if half_mass_radius > sorted_radius[-1]:
-        raise RuntimeError(
-            "Half mass radius larger than input radii:"
-            f" half_mass_radius = {half_mass_radius},"
-            f" sorted_radius[-1] = {sorted_radius[-1]}!"
-            f" ihalf = {ihalf}, Npart = {len(radius)},"
-            f" target_mass = {target_mass},"
-            f" rmin = {rmin}, rmax = {rmax},"
-            f" Mmin = {Mmin}, Mmax = {Mmax},"
-            f" sorted_radius = {sorted_radius},"
-            f" cumulative_mass = {cumulative_mass}"
-        )
-
-    return half_mass_radius
+    return get_half_weight_radius(radius, mass, total_mass) 
 
 def get_half_light_radius(
     radius: unyt.unyt_array, mass: unyt.unyt_array, total_mass: unyt.unyt_quantity

--- a/SOAP/property_calculation/half_mass_radius.py
+++ b/SOAP/property_calculation/half_mass_radius.py
@@ -144,7 +144,7 @@ def get_half_light_radius(
     Returns the half light radius, defined as the radius at which the cumulative mass profile
     reaches 0.5 * total_luminosity, for each GAMA band.
     """
-    half_light_radii = np.zeros(luminosity.shape[1]) * radius.units
+    half_light_radii = np.zeros(total_band_luminosites.shape[0]) * radius.units
     for i_band, (luminosity, total_luminosity) in enumerate(zip(band_luminosity.T, total_band_luminosites)):
         half_light_radii[i_band] = get_half_weight_radius(radius, luminosity, total_luminosity)
     return half_light_radii

--- a/SOAP/property_calculation/half_mass_radius.py
+++ b/SOAP/property_calculation/half_mass_radius.py
@@ -120,83 +120,31 @@ def get_half_mass_radius(
     return get_half_weight_radius(radius, mass, total_mass) 
 
 def get_half_light_radius(
-    radius: unyt.unyt_array, mass: unyt.unyt_array, total_mass: unyt.unyt_quantity
+    radius: unyt.unyt_array, band_luminosity: unyt.unyt_array, total_band_luminosites: unyt.unyt_array
 ) -> unyt.unyt_quantity:
     """
-    Get the half mass radius of the given particle distribution.
+    Get the half light radius of the given particle distribution for the 9 GAMA 
+    bands.
 
-    We obtain the half mass radius by sorting the particles on radius and then computing
-    the cumulative mass profile from this. We then determine in which "bin" the cumulative
-    mass profile intersects the target half mass value and obtain the corresponding
+    We obtain the half light radius by sorting the particles on radius and then computing
+    the cumulative light profile from this. We then determine in which "bin" the cumulative
+    light profile intersects the target half light value and obtain the corresponding
     radius from linear interpolation.
 
     Parameters:
      - radius: unyt.unyt_array
        Radii of the particles.
-     - mass: unyt.unyt_array
-       Mass of the particles.
-     - total_mass: unyt.unyt_quantity
-       Total mass of the particles. Should be mass.sum(). We pass this on as an argument
-       because this value might already have been computed before. If it was not, then
-       computing it in the function call is still an efficient way to do this.
+     - band_luminosity: unyt.unyt_array
+       Luminosity of the particles in each GAMA band.
+     - total_band_luminosites: unyt.unyt_array
+       Total luminosisty of the particles in each GAMA band. Should be luminosity.sum(axis=0). 
+       We pass this on as an argument because this value might already have been computed before. 
+       If it was not, then computing it in the function call is still an efficient way to do this.
 
-    Returns the half mass radius, defined as the radius at which the cumulative mass profile
-    reaches 0.5*total_mass.
+    Returns the half light radius, defined as the radius at which the cumulative mass profile
+    reaches 0.5 * total_luminosity, for each GAMA band.
     """
-    if total_mass == 0.0 * total_mass.units or len(mass) < 1:
-        return 0.0 * radius.units
-
-    target_mass = 0.5 * total_mass
-
-    isort = np.argsort(radius)
-    sorted_radius = radius[isort]
-    # compute sum in double precision to avoid numerical overflow due to
-    # weird unit conversions in unyt
-    cumulative_mass = mass[isort].cumsum(dtype=np.float64)
-
-    # consistency check
-    # np.sum() and np.cumsum() use different orders, so we have to allow for
-    # some small difference
-    if cumulative_mass[-1] < 0.999 * total_mass:
-        raise RuntimeError(
-            "Masses sum up to less than the given total mass:"
-            f" cumulative_mass[-1] = {cumulative_mass[-1]},"
-            f" total_mass = {total_mass}!"
-        )
-
-    # find the intersection point
-    # if that is the first bin, set the lower limits to 0
-    ihalf = np.argmax(cumulative_mass >= target_mass)
-    if ihalf == 0:
-        rmin = 0.0 * radius.units
-        Mmin = 0.0 * mass.units
-    else:
-        rmin = sorted_radius[ihalf - 1]
-        Mmin = cumulative_mass[ihalf - 1]
-    rmax = sorted_radius[ihalf]
-    Mmax = cumulative_mass[ihalf]
-
-    # now get the radius by linearly interpolating
-    # if the bin edges coincide (two particles at exactly the same radius)
-    # then we simply take that radius
-    if Mmin == Mmax:
-        half_mass_radius = 0.5 * (rmin + rmax)
-    else:
-        half_mass_radius = rmin + (target_mass - Mmin) / (Mmax - Mmin) * (rmax - rmin)
-
-    # consistency check
-    # we cannot use '>=', since equality would happen if half_mass_radius==0
-    if half_mass_radius > sorted_radius[-1]:
-        raise RuntimeError(
-            "Half mass radius larger than input radii:"
-            f" half_mass_radius = {half_mass_radius},"
-            f" sorted_radius[-1] = {sorted_radius[-1]}!"
-            f" ihalf = {ihalf}, Npart = {len(radius)},"
-            f" target_mass = {target_mass},"
-            f" rmin = {rmin}, rmax = {rmax},"
-            f" Mmin = {Mmin}, Mmax = {Mmax},"
-            f" sorted_radius = {sorted_radius},"
-            f" cumulative_mass = {cumulative_mass}"
-        )
-
-    return half_mass_radius
+    half_light_radii = np.zeros(luminosity.shape[1]) * radius.units
+    for i_band, (luminosity, total_luminosity) in enumerate(zip(band_luminosity.T, total_band_luminosites)):
+        half_light_radii[i_band] = get_half_weight_radius(radius, luminosity, total_luminosity)
+    return half_light_radii

--- a/SOAP/property_calculation/half_mass_radius.py
+++ b/SOAP/property_calculation/half_mass_radius.py
@@ -3,7 +3,8 @@
 """
 half_mass_radius.py
 
-Utility functions to compute the half mass radius of a particle distribution.
+Utility functions to compute the half mass or half light radius of a particle 
+distribution.
 
 We put this in a separate file to facilitate unit testing.
 """
@@ -13,6 +14,88 @@ import unyt
 
 
 def get_half_mass_radius(
+    radius: unyt.unyt_array, mass: unyt.unyt_array, total_mass: unyt.unyt_quantity
+) -> unyt.unyt_quantity:
+    """
+    Get the half mass radius of the given particle distribution.
+
+    We obtain the half mass radius by sorting the particles on radius and then computing
+    the cumulative mass profile from this. We then determine in which "bin" the cumulative
+    mass profile intersects the target half mass value and obtain the corresponding
+    radius from linear interpolation.
+
+    Parameters:
+     - radius: unyt.unyt_array
+       Radii of the particles.
+     - mass: unyt.unyt_array
+       Mass of the particles.
+     - total_mass: unyt.unyt_quantity
+       Total mass of the particles. Should be mass.sum(). We pass this on as an argument
+       because this value might already have been computed before. If it was not, then
+       computing it in the function call is still an efficient way to do this.
+
+    Returns the half mass radius, defined as the radius at which the cumulative mass profile
+    reaches 0.5*total_mass.
+    """
+    if total_mass == 0.0 * total_mass.units or len(mass) < 1:
+        return 0.0 * radius.units
+
+    target_mass = 0.5 * total_mass
+
+    isort = np.argsort(radius)
+    sorted_radius = radius[isort]
+    # compute sum in double precision to avoid numerical overflow due to
+    # weird unit conversions in unyt
+    cumulative_mass = mass[isort].cumsum(dtype=np.float64)
+
+    # consistency check
+    # np.sum() and np.cumsum() use different orders, so we have to allow for
+    # some small difference
+    if cumulative_mass[-1] < 0.999 * total_mass:
+        raise RuntimeError(
+            "Masses sum up to less than the given total mass:"
+            f" cumulative_mass[-1] = {cumulative_mass[-1]},"
+            f" total_mass = {total_mass}!"
+        )
+
+    # find the intersection point
+    # if that is the first bin, set the lower limits to 0
+    ihalf = np.argmax(cumulative_mass >= target_mass)
+    if ihalf == 0:
+        rmin = 0.0 * radius.units
+        Mmin = 0.0 * mass.units
+    else:
+        rmin = sorted_radius[ihalf - 1]
+        Mmin = cumulative_mass[ihalf - 1]
+    rmax = sorted_radius[ihalf]
+    Mmax = cumulative_mass[ihalf]
+
+    # now get the radius by linearly interpolating
+    # if the bin edges coincide (two particles at exactly the same radius)
+    # then we simply take that radius
+    if Mmin == Mmax:
+        half_mass_radius = 0.5 * (rmin + rmax)
+    else:
+        half_mass_radius = rmin + (target_mass - Mmin) / (Mmax - Mmin) * (rmax - rmin)
+
+    # consistency check
+    # we cannot use '>=', since equality would happen if half_mass_radius==0
+    if half_mass_radius > sorted_radius[-1]:
+        raise RuntimeError(
+            "Half mass radius larger than input radii:"
+            f" half_mass_radius = {half_mass_radius},"
+            f" sorted_radius[-1] = {sorted_radius[-1]}!"
+            f" ihalf = {ihalf}, Npart = {len(radius)},"
+            f" target_mass = {target_mass},"
+            f" rmin = {rmin}, rmax = {rmax},"
+            f" Mmin = {Mmin}, Mmax = {Mmax},"
+            f" sorted_radius = {sorted_radius},"
+            f" cumulative_mass = {cumulative_mass}"
+        )
+
+    return half_mass_radius
+
+def get_half_light_radius(
     radius: unyt.unyt_array, mass: unyt.unyt_array, total_mass: unyt.unyt_quantity
 ) -> unyt.unyt_quantity:
     """

--- a/SOAP/property_table.py
+++ b/SOAP/property_table.py
@@ -1234,7 +1234,7 @@ class PropertyTable:
             a_scale_exponent=1,
         ),
         "HalfLightRadiusStar": Property(
-            name="HalfLightRadiusStar",
+            name="HalfLightRadiusStars",
             shape=9,
             dtype=np.float32,
             unit="snap_length",

--- a/SOAP/property_table.py
+++ b/SOAP/property_table.py
@@ -1233,6 +1233,18 @@ class PropertyTable:
             output_physical=False,
             a_scale_exponent=1,
         ),
+        "HalfLightRadiusStar": Property(
+            name="HalfLightRadiusStar",
+            shape=9,
+            dtype=np.float32,
+            unit="snap_length",
+            description="Stellar half light radius in the 9 GAMA bands.",
+            lossy_compression_filter="FMantissa9",
+            dmo_property=False,
+            particle_properties=["PartType4/Coordinates", "PartType4/Masses", "PartType4/Luminosities"],
+            output_physical=False,
+            a_scale_exponent=1,
+        ),
         "HalfMassRadiusTot": Property(
             name="HalfMassRadiusTotal",
             shape=1,

--- a/parameter_files/COLIBRE_HYBRID.yml
+++ b/parameter_files/COLIBRE_HYBRID.yml
@@ -122,6 +122,7 @@ ApertureProperties:
     HalfMassRadiusGas: general
     HalfMassRadiusDust: general
     HalfMassRadiusStars: true
+    HalfLightRadiusStars: false
     HeliumMass: true
     HydrogenMass: true
     KappaCorotBaryons: general
@@ -306,6 +307,7 @@ ProjectedApertureProperties:
     HalfMassRadiusGas: general
     HalfMassRadiusDust: general
     HalfMassRadiusStars: true
+    HalfLightRadiusStars: false
     HeliumMass: true
     HydrogenMass: true
     MolecularHydrogenMass: true
@@ -564,6 +566,7 @@ SubhaloProperties:
     HalfMassRadiusGas: general
     HalfMassRadiusDust: general
     HalfMassRadiusStars: true
+    HalfLightRadiusStars: false
     HalfMassRadiusTotal: true
     EncloseRadius: true
     KappaCorotBaryons: general

--- a/parameter_files/COLIBRE_THERMAL.yml
+++ b/parameter_files/COLIBRE_THERMAL.yml
@@ -122,6 +122,7 @@ ApertureProperties:
     HalfMassRadiusGas: general
     HalfMassRadiusDust: general
     HalfMassRadiusStars: true
+    HalfLightRadiusStars: false
     HeliumMass: true
     HydrogenMass: true
     KappaCorotBaryons: general
@@ -306,6 +307,7 @@ ProjectedApertureProperties:
     HalfMassRadiusGas: general
     HalfMassRadiusDust: general
     HalfMassRadiusStars: true
+    HalfLightRadiusStars: false
     HeliumMass: true
     HydrogenMass: true
     MolecularHydrogenMass: true
@@ -564,6 +566,7 @@ SubhaloProperties:
     HalfMassRadiusGas: general
     HalfMassRadiusDust: general
     HalfMassRadiusStars: true
+    HalfLightRadiusStars: false
     HalfMassRadiusTotal: true
     EncloseRadius: true
     KappaCorotBaryons: general


### PR DESCRIPTION
This PR adds functions to compute the half-light radii for each GAMA band. 

Based on the feedback from #135, I have taken the approach to generalise the function previously used to compute the half-mass radius. I then use the general function to compute half-mass and half-light radii.