### PR TITLE
Script to obtain the SOAP property evolution for specified HBT-HERONS subhaloes 

### DIFF
--- a/misc/README.md
+++ b/misc/README.md
@@ -7,14 +7,16 @@ subhaloes at a time, as above this limit h5py fancy indexing is much slower than
 loading the whole catalogue directly.
 
 The script works by opening in parallel each of the SOAP catalogue files available in
-the provided  base directory, finding the target `TrackIDs` and getting the values of each
+the provided base directory, finding the target `TrackIDs` and getting the values of each
 property of interest. After opening every available SOAP catalogue, the collected
 data is saved to an HDF5 file.
+
+It only supports SOAP catalogues generated using HBT-HERONS or HBT+.
 
 ### Running
 
 The MPI routines used to load the SOAP catalogues in parallel use the [VirgoDC](https://github.com/jchelly/VirgoDC) 
-package. If using COSMA, you can run `./scripts/cosma_python_env.sh` from the SOAP basefolder
+package. If using COSMA, you can run `./scripts/cosma_python_env.sh` from the SOAP base folder
 to install the required packages in a virtual enviroment.
 
 The following options need to be provided when running the scripts:

--- a/misc/README.md
+++ b/misc/README.md
@@ -1,3 +1,44 @@
+## Retrieving the evolution of subhaloes for selected properties
+
+This repository contains a script (`get_evolution_HBT_tracks.py`) used to generate 
+a HDF5 file that contains the property evolution for a subset of selected subhalos.
+Using the script is recommended when looking at the evolution of more than ~1000
+subhaloes at a time, as above this limit h5py fancy indexing is much slower than 
+loading the whole catalogue directly.
+
+The script works by opening in parallel each of the SOAP catalogue files available in
+the provided  base directory, finding the target `TrackIDs` and getting the values of each
+property of interest. After opening every available SOAP catalogue, the collected
+data is saved to an HDF5 file.
+
+### Running
+
+The MPI routines used to load the SOAP catalogues in parallel use the [VirgoDC](https://github.com/jchelly/VirgoDC) 
+package. If using COSMA, you can run `./scripts/cosma_python_env.sh` from the SOAP basefolder
+to install the required packages in a virtual enviroment.
+
+The following options need to be provided when running the scripts:
+
+  - `SOAP_basedir`: Path to the directory containing the SOAP catalogues for the run, which are assumed to be named as `SOAP_basedir/halo_properties_*.hdf5`.
+  - `output_file`: Name of the HDF5 file where the property evolution will be saved for each subhalo.
+  - `-tracks` or `-t`: Path to a text file containing the `TrackId` of the subhaloes of interest. Each row should only contain a single `TrackId` value.
+  - `-properties` or `-p`: Path to a text file containing the SOAP properties to save. Each row should only specify a single property, which should be the absolute path to the dataset within the SOAP catalogue (e.g. `ExclusiveSphere/50kpc/StellarMass`).
+
+To run in MPI (recommended), you can do:
+
+```bash
+mpirun -np <NUMBER_MPI_RANKS> -- python3 -m mpi4py get_evolution_HBT_tracks.py <SOAP_basedir> <output_file> -tracks <PATH_TO_TRACKS.TXT> -properties <PATH_TO_PROPERTIES.TXT>
+```
+### Output
+
+The HDF5 file saved by the script has a similar structure to SOAP catalogues,
+but with a few important differences. Here are the main highlights:
+
+  - There is no unit information. Additionally, quantities can be in comoving or physical units depending on what SOAP decided to use and save. Triple check what SOAP does.
+  - The name of each property dataset matches the name in the original SOAP catalogues.
+  - Each row in a given property dataset corresponds to a different TrackId, with the column being the value of the corresponding property at different output times.
+  - An additional dataset indicating the output time of SOAP catalogues (`Redshift`) is always provided.
+
 ## Matching halos between outputs
 
 This repository also contains a script to find halos which contain the same

--- a/misc/get_evolution_HBT_tracks.py
+++ b/misc/get_evolution_HBT_tracks.py
@@ -1,0 +1,164 @@
+#!/bin/env python
+ 
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+comm_rank = comm.Get_rank()
+comm_size = comm.Get_size()
+
+import h5py
+import numpy as np
+from glob import glob
+
+import virgo.mpi.util
+import virgo.mpi.parallel_hdf5 as phdf5
+import virgo.mpi.parallel_sort as psort
+
+def get_SOAP_property_evolution(SOAP_paths, TrackIDs_to_follow, properties):
+    """
+    Loads the SOAP catalogues in parallel and retrieves for each catalogue 
+    the specified properties for the provided TrackIDs.
+
+    Parameters
+    ----------
+    SOAP_paths: list of str
+        List of sorted strings where each one provides the path to a single SOAP
+        catalogue.
+    TrackIDs_to_follow: np.ndarray
+        TrackId of the subhaloes we are interested in.
+    properties: list of str
+        The properties we want to retrieve for each fo the provided TrackIDs.
+
+    Returns
+    -------
+    redshift_evolution: np.ndarray
+        The redshifts at which each SOAP catalogue was saved.
+    property_evolution: dict of np.ndarray
+        Dictionary where each entry corresponds to the evolution of the requested
+        properties for the TrackIDs that are in the local MPI rank.
+    """
+
+    # We balance the number of Tracks across the tasks we have
+    TrackIDs_to_follow = psort.parallel_unique(TrackIDs_to_follow, repartition_output=True)
+
+    # Final dictionary with the data we will save.
+    property_evolution = dict([(property, []) for property in properties])
+
+    # Redshifts at which we loaded the SOAP catalogues.
+    redshift_evolution = -np.ones(len(SOAP_paths))
+
+    for i, path in enumerate(SOAP_paths):
+
+        if comm_rank ==0:
+            print(f"Reading SOAP catalogue: {path}", end=' --- ')
+
+        with h5py.File(path, 'r') as SOAP_catalogue:
+            redshift_evolution[i] = SOAP_catalogue['Header'].attrs['Redshift'][0]
+
+        mf = phdf5.MultiFile([path], comm=comm,)
+        data = {}
+        for property in properties:
+            data[property] = mf.read(property)
+        del mf
+
+        # Each rank will find the entry with the TrackID they are supposed to use.
+        order = psort.parallel_match(TrackIDs_to_follow, data["InputHalos/HBTplus/TrackId"])
+
+        # Get the properties we want
+        for property in properties:
+            property_evolution[property].append([psort.fetch_elements(data[property], order, comm=comm)])
+
+        if comm_rank == 0:
+            print("DONE") 
+
+    return redshift_evolution, property_evolution
+
+def save_evolution(redshift_evolution, property_evolution, output_file):
+    """
+    Saves the property evolution of the subhaloes in a specified HDF5 file path.
+
+    Parameters
+    ----------
+    redshift_evolution: np.ndarray
+        The redshifts at which each SOAP catalogue was saved.
+    property_evolution: dict of np.ndarray
+        Dictionary where each entry corresponds to the evolution of the requested
+        properties for the TrackIDs that are in the local MPI rank.
+    output_file: str
+        Location where to save the HDF5 containing the evolution of TrackIDs.
+    """
+
+    if comm_rank ==0:
+        print(f"Saving output", end=' --- ')
+
+    # We create a single array for each output property
+    with h5py.File(output_file, 'w', driver='mpio', comm=comm) as outfile:
+
+        for property in property_evolution.keys():
+            data_to_save = np.concatenate(property_evolution[property]).T
+
+            names = property.split('/')
+            group_name = '/'.join(names[:-1])
+            dset_name  = names[-1]
+
+            if group_name in outfile:
+                group = outfile[group_name]
+            else:
+                group = outfile.create_group(group_name)
+
+            phdf5.collective_write(group, dset_name, data_to_save, comm)
+
+        # Save the redshift for future use
+        dset = outfile.create_dataset('Redshift', dtype=redshift_evolution.dtype)
+        if comm_rank == 0:
+            dset[...] = redshift_evolution
+
+    comm.Barrier()
+    if comm_rank == 0:
+        print("DONE")
+
+def get_track_evolution(SOAP_basedir, output_file, tracks, properties):
+    """
+    Loads in parallel the SOAP properties for each catalogue in the provided 
+    base directory, retrieves the specified properties for each TrackID of interest.
+    Saves the property evolution in a HDF5 file.
+
+    Parameters
+    ----------
+    SOAP_basedir: str
+        Path to the directory containing all SOAP catalogues.
+    output_file: str
+        Location the HDF5 containing the evolution of TrackIDs is saved.
+    tracks: np.ndarray
+        The TrackID of the subhaloes we are interesting in following.
+    properties: np.ndarray
+        The SOAP properties we are interested in following.
+    """
+
+    # Get all paths by default
+    SOAP_paths = sorted(glob(f"{SOAP_basedir}/halo_properties_*.hdf5"))
+
+    if comm_rank ==0:
+        print (f"Getting the evolution of {len(properties)} properties for {len(tracks)} TrackIDs. There are {len(SOAP_paths)} SOAP files available in the specified directory.")
+
+    # Get the evolution
+    redshift_evolution, property_evolution = get_SOAP_property_evolution(SOAP_paths, tracks, properties)
+
+    comm.Barrier()
+
+    # Save in a separate file for future use
+    save_evolution(redshift_evolution, property_evolution, output_file)
+
+if __name__ == "__main__":
+
+    from virgo.mpi.util import MPIArgumentParser
+
+    parser = MPIArgumentParser(comm, description="Obtain the evolution of the specified SOAP properties for the provided TrackIds.")
+    parser.add_argument("SOAP_basedir", type=str, help="Root directory of the the SOAP catalogues.")
+    parser.add_argument("output_file",  type=str, help="File in which to write the output.")
+    parser.add_argument('-t', '--tracks', help='Comma-separated string containing the TrackIDs to follow.',
+        type=lambda s: [int(item) for item in s.split(',')])
+    parser.add_argument('-p', '--properties', help='Comma-separated string containing which properties to follow.',
+        type=lambda s: [str(item) for item in s.split(',')])
+    args = parser.parse_args()
+
+    get_track_evolution(**vars(args))

--- a/misc/get_evolution_HBT_tracks.py
+++ b/misc/get_evolution_HBT_tracks.py
@@ -108,9 +108,7 @@ def save_evolution(redshift_evolution, property_evolution, output_file):
             phdf5.collective_write(group, dset_name, data_to_save, comm)
 
         # Save the redshift for future use
-        dset = outfile.create_dataset('Redshift', dtype=redshift_evolution.dtype)
-        if comm_rank == 0:
-            dset[...] = redshift_evolution
+        dset = outfile.create_dataset("Redshift", data=redshift_evolution)
 
     comm.Barrier()
     if comm_rank == 0:

--- a/misc/get_evolution_HBT_tracks.py
+++ b/misc/get_evolution_HBT_tracks.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
     parser = MPIArgumentParser(comm, description="Obtain the evolution of the specified SOAP properties for the provided TrackIds.")
     parser.add_argument("SOAP_basedir", type=str, help="Root directory of the the SOAP catalogues.")
     parser.add_argument("output_file",  type=str, help="File in which to write the output.")
-    parser.add_argument('-t', '--track_path', type=str, dest="track_path", help='Path to a text file containing in each row a TrackId whose evolution are interested in tracking.')
+    parser.add_argument('-t', '--tracks', type=str, dest="track_path", help='Path to a text file containing in each row a TrackId whose evolution are interested in tracking.')
     parser.add_argument('-p', '--properties', type=str, dest="property_path", help='Path to a text file containing in each row a SOAP property that we are interested in tracking.')
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR creates a script that uses VirgoDC tools to open SOAP catalogues in parallel, and retrieve certain properties of interest for the specified subhaloes.

I think it is useful to have since retrieving the evolution of more than O(1000) subhaloes using pointers directly from SOAP will be slow (see warning about h5py fancy indexing in https://docs.h5py.org/en/stable/high/dataset.html#dataset-fancy).

I have not added a separate README, since the one in misc folder is for the matching script only (perhaps the name of README is a bit too general if it does not address the other scripts here). Happy to add some more documentation in any case. 


To run, you only need to supply the basedir of SOAP paths and which properties and TrackIDs you want to have, e.g. (after activating cosma enviroment)

```
mpirun -np 2 -- python3 -m mpi4py get_evolution_HBT_tracks.py "/cosma/home/durham/dc-foro1/data_links/colibre/L012_m5/THERMAL_AGN_m5_obsolete/SOAP/" "output.hdf5" -t 491,782,224,1083,73 ,9,713,70,3621,15 -p ExclusiveSphere/50kpc/KappaCorotStars,ExclusiveSphere/50kpc/StellarMass,InputHalos/HBTplus/TrackId
```