### PR TITLE
Set lower limit

### DIFF
--- a/SOAP/particle_selection/aperture_properties.py
+++ b/SOAP/particle_selection/aperture_properties.py
@@ -1925,9 +1925,9 @@ class ApertureParticleData:
         """
         if self.Ngas == 0:
             return None
-        return self.get_dataset("PartType0/TotalDustMassFractions")[self.gas_mask_all][
-            self.gas_mask_ap
-        ]
+        mass_frac = self.get_dataset("PartType0/TotalDustMassFractions")[self.gas_mask_all][self.gas_mask_ap]
+        mass_frac[mass_frac < 10**(-10)] = 0 * unyt.dimensionless
+        return mass_frac
 
     @lazy_property
     def gas_dust_mass_fractions(self) -> unyt.unyt_array:
@@ -1936,9 +1936,9 @@ class ApertureParticleData:
         """
         if self.Ngas == 0:
             return None
-        return self.get_dataset("PartType0/DustMassFractions")[self.gas_mask_all][
-            self.gas_mask_ap
-        ]
+        mass_frac = self.get_dataset("PartType0/DustMassFractions")[self.gas_mask_all][self.gas_mask_ap]
+        mass_frac[mass_frac < 10**(-10)] = 0 * unyt.dimensionless
+        return mass_frac
 
     @lazy_property
     def gas_dust_mass_fractions_graphite_large(self) -> unyt.unyt_array:

--- a/SOAP/particle_selection/subhalo_properties.py
+++ b/SOAP/particle_selection/subhalo_properties.py
@@ -341,7 +341,9 @@ class SubhaloParticleData:
         """
         if self.Ngas == 0:
             return None
-        return self.get_dataset("PartType0/TotalDustMassFractions")[self.gas_mask_all]
+        mass_frac = self.get_dataset("PartType0/TotalDustMassFractions")[self.gas_mask_all]
+        mass_frac[mass_frac < 10**(-10)] = 0 * unyt.dimensionless
+        return mass_frac
 
     @lazy_property
     def Mdm(self) -> unyt.unyt_quantity:


### PR DESCRIPTION
Dust mass fractions can be arbitrary low (close to FLT_MIN) in COLIBRE. Compressing these values can give weird results, which causes the different dust masses to not sum to the total dust mass fraction. Setting a lower limit on the values solves this problem.