### PR TITLE
Read ordered HBT catalogues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SOAP: Spherical Overdensity and Aperture Processor
 
 This repository contains programs which can be used to compute
-properties of halos in spherical apertures in SWIFT[https://swift.strw.leidenuniv.nl/] snapshots.
+properties of halos in spherical apertures in [SWIFT](https://swift.strw.leidenuniv.nl/) snapshots.
 The resulting output halo catalogues can be read using the
 [swiftsimio](https://swiftsimio.readthedocs.io/en/latest/)
 python package.

--- a/SOAP/core/combine_chunks.py
+++ b/SOAP/core/combine_chunks.py
@@ -684,8 +684,9 @@ def combine_chunks(
             # Check if the previous/next HBT catalogue is available
             prev_basename = args.halo_basename.format(snap_nr=snap_nr)
             if comm_world.Get_rank() == 0:
+                # Check for sorted and unsorted catalogues
                 prev_filename = prev_basename + ".0.hdf5"
-                if os.path.exists(prev_filename):
+                if os.path.exists(prev_basename) or os.path.exists(prev_filename):
                     calculate_prev_index = True
                 else:
                     print(f"Can't find halo catalogues for calculating {name}Index")

--- a/parameter_files/README.md
+++ b/parameter_files/README.md
@@ -42,7 +42,9 @@ If a dataset is present in both the snapshot and the extra input files, the valu
 Settings for the halo finding algorithm and output file locations.
 
 - **type**: The subhalo finder being used. Possible options are `HBTplus`, `VR`, `Subfind`, and `Rockstar`.
-- **filename**: Template for input halo catalogue files. The format of this depends on the halo finder as they have different output structure. HBTplus example: `"{sim_dir}/{sim_name}/HBT/{snap_nr:03d}/SubSnap_{snap_nr:03d}"`
+- **filename**: Template for input halo catalogue files. The format of this depends on the halo finder as they each have a different output structure.
+  - HBTplus: `"{sim_dir}/{sim_name}/HBT/{snap_nr:03d}/SubSnap_{snap_nr:03d}"`
+  - Sorted HBTplus: `"{sim_dir}/{sim_name}/HBT/{snap_nr:03d}/OrderedSubSnap_{snap_nr:03d}.hdf5"`
 - **fof_filename**: Template for FOF catalog files. Used for storing host FOF information for central subhalos. Only supported for HBTplus
 - **fof_radius_filename**: Template for FOF catalog files which contain the "Groups/Radii" dataset. These were produced by a post-processing script, and are missing from the main FOFs
 - **read_potential_energies**: Optional boolean value, defaults to False. Whether to read potential energies and place them in the membership files. Only supported for HBTplus


### PR DESCRIPTION
The raw HBT output is unsorted, but there is a script which sorted the subhalos based on their track id. This is useful to have for any people working with the HBT files themselves. However, it is also useful for soap since then `HaloCatalogueIndex` will be equal to `TrackId`, which people often get confused between.

This PR updates the read routines for HBT catalogues. The old unsorted catalogues are still supported