### PR TITLE
Update FOF radii script

### DIFF
--- a/misc/calculate_fof_radii.py
+++ b/misc/calculate_fof_radii.py
@@ -1,12 +1,12 @@
 #!/bin/env python
 
 """
-calculate_fof_positions.py
+calculate_fof_radii.py
 
-This script calculates the maximum and minimum particles positions for each FOF.
+This script calculates the maximum particle radii for each FOF.
 Usage:
 
-  mpirun -- python misc/calculate_fof_positions.py \
+  mpirun -- python misc/calculate_fof_radii.py \
           --snap-basename=SNAPSHOT \
           --fof-basename=FOF \
           --output-basename=OUTPUT
@@ -14,6 +14,9 @@ Usage:
 where SNAPSHOT is the basename of the snapshot files (the snapshot
 name without the .{file_nr}.hdf5 suffix), FOF is the basename of the
 fof catalogues, and OUTPUT is the basename of the output fof catalogues.
+
+For a full list of optional arguments run:
+  python misc/calculate_fof_radii.py -h
 """
 
 import argparse
@@ -57,21 +60,19 @@ parser.add_argument(
     "--output-basename",
     type=str,
     required=True,
-    help=("The basename for the output files"),
+    help="The basename for the output files",
 )
 parser.add_argument(
     "--null-fof-id",
     type=int,
     required=False,
     default=2147483647,
-    help=("The FOFGroupIDs of particles not in a FOF group"),
+    help="The FOFGroupIDs of particles not in a FOF group",
 )
 parser.add_argument(
     "--copy-datasets",
-    type=bool,
-    required=False,
-    default=False,
-    help=("Copy datasets from input FoF files (otherwise a link is created)"),
+    action='store_true',
+    help="Copy datasets from input FoF files (otherwise a link is created)",
 )
 parser.add_argument(
     "--n-test",
@@ -80,33 +81,66 @@ parser.add_argument(
     default=0,
     help="The number of FOFs to check. If -1 all objects will be checked",
 )
+parser.add_argument(
+    "--single-fof-file",
+    action='store_true',
+    help="If there is a single FoF file even though there are distributed snapshots",
+)
+parser.add_argument(
+    "--recalculate-sizes",
+    action='store_true',
+    help="Whether to calculate the number of particles in each FOF group",
+)
+parser.add_argument(
+    "--reset-ids",
+    action='store_true',
+    help=(
+        "Whether to set the group ids in the FOF catalgoues to 1...N ",
+        "(This is required for some runs as there was a bug where the incorrect",
+        "IDs were output)",
+    ),
+)
 
 args = parser.parse_args()
 snap_filename = args.snap_basename + ".{file_nr}.hdf5"
-fof_filename = args.fof_basename + ".{file_nr}.hdf5"
-output_filename = args.output_basename + ".{file_nr}.hdf5"
+if args.single_fof_file:
+    fof_filename = args.fof_basename + ".hdf5"
+    output_filename = args.output_basename + ".hdf5"
+else:
+    fof_filename = args.fof_basename + ".{file_nr}.hdf5"
+    output_filename = args.output_basename + ".{file_nr}.hdf5"
 os.makedirs(os.path.dirname(output_filename), exist_ok=True)
 
 if comm_rank == 0:
     start_time = time.time()
-    print(f"Running with {comm_size} ranks")
-    print(f"snap_filename: {snap_filename}")
-    print(f"fof_filename: {fof_filename}")
-    print(f"output_filename: {output_filename}")
-    print(f"null_fof_id: {args.null_fof_id}")
+    with h5py.File(fof_filename.format(file_nr=0), "r") as file:
+        fof_header = dict(file["Header"].attrs)
+        unit_attrs = {
+            'Radii': dict(file["Groups/Centres"].attrs),
+            'Sizes': dict(file["Groups/Sizes"].attrs),
+            'GroupIDs': dict(file["Groups/GroupIDs"].attrs),
+        }
     with h5py.File(snap_filename.format(file_nr=0), "r") as file:
-        header = dict(file["Header"].attrs)
-        coordinate_unit_attrs = dict(file["PartType1/Coordinates"].attrs)
+        snap_header = dict(file["Header"].attrs)
+    print(f"Running with {comm_size} ranks")
+    for k, v in vars(args).items():
+        print(f'  {k}: {v}')
+    print(f'  nr_files: {fof_header["NumFilesPerSnapshot"][0]}')
 else:
-    header = None
-    coordinate_unit_attrs = None
-header = comm.bcast(header)
-coordinate_unit_attrs = comm.bcast(coordinate_unit_attrs)
+    fof_header = None
+    snap_header = None
+    unit_attrs = None
+fof_header = comm.bcast(fof_header)
+snap_header = comm.bcast(snap_header)
+unit_attrs = comm.bcast(unit_attrs)
 
-boxsize = header["BoxSize"]
-ptypes = np.where(header["TotalNumberOfParticles"] != 0)[0]
-nr_files = header["NumFilesPerSnapshot"][0]
+boxsize = snap_header["BoxSize"]
+ptypes = np.where(snap_header["TotalNumberOfParticles"] != 0)[0]
+nr_files = fof_header["NumFilesPerSnapshot"][0]
 
+# If we are recalculating the sizes we should just a create a fresh file
+if args.recalculate_sizes or args.reset_ids:
+    assert args.copy_datasets
 
 def copy_attrs(src_obj, dst_obj):
     for key, val in src_obj.attrs.items():
@@ -118,6 +152,10 @@ def copy_object(src_obj, dst_obj, src_filename, prefix="", skip_datasets=False):
     for name, item in src_obj.items():
         if isinstance(item, h5py.Dataset):
             if skip_datasets and (item.name != "/Header/PartTypeNames"):
+                continue
+            if (item.name == '/Groups/Sizes') and args.recalculate_sizes:
+                continue
+            if (item.name == '/Groups/GroupIDs') and args.reset_ids:
                 continue
             if args.copy_datasets:
                 src_obj.copy(name, dst_obj)
@@ -168,9 +206,13 @@ for i_file in range(
 fof_file = phdf5.MultiFile(
     fof_filename, file_nr_attr=("Header", "NumFilesPerSnapshot"), comm=comm
 )
-fof_group_ids = fof_file.read(f"Groups/GroupIDs")
 fof_sizes = fof_file.read(f"Groups/Sizes")
 fof_centres = fof_file.read(f"Groups/Centres")
+fof_group_ids = fof_file.read(f"Groups/GroupIDs")
+if args.reset_ids:
+    n_fof = fof_group_ids.shape[0]
+    fof_offset = comm.scan(n_fof, op=MPI.SUM) - n_fof
+    fof_group_ids = np.arange(n_fof, dtype=fof_group_ids.dtype) + fof_offset + 1
 
 # Initialise arrays for storing results
 fof_radius = np.zeros_like(fof_centres[:, 0])
@@ -278,12 +320,17 @@ for ptype in ptypes:
     fof_radius[mask] = np.maximum(fof_radius[mask], radius)
 
 # Carry out some sanity checks
-assert np.all(total_part_counts == fof_sizes), "Not all particles found for some FOFs"
 assert np.all(fof_radius > 0)
+output_data = {"Radii": fof_radius}
+if args.recalculate_sizes:
+    output_data["Sizes"] = total_part_counts
+else:
+    msg = "Not all particles found for some FOFs"
+    assert np.all(total_part_counts == fof_sizes), msg
+if args.reset_ids:
+    output_data["GroupIDs"] = fof_group_ids
 
 # Write data to file
-output_data = {"Radii": fof_radius}
-attrs = {"Radii": coordinate_unit_attrs}
 elements_per_file = fof_file.get_elements_per_file("Groups/GroupIDs")
 fof_file.write(
     output_data,
@@ -291,10 +338,10 @@ fof_file.write(
     filenames=output_filename,
     mode="r+",
     group="Groups",
-    attrs=attrs,
+    attrs=unit_attrs,
 )
 
-if comm_rank == 0:
+if (comm_rank == 0) and (not args.single_fof_file):
 
     # Create virtual file
     dst_filename = args.output_basename + ".hdf5"
@@ -344,35 +391,36 @@ if comm_rank == 0:
     print("New files generated!")
     print(f"Took {int(time.time() - start_time)} seconds")
 
-    if args.n_test != 0:
-        print("Testing we can load all particles")
-        import swiftsimio as sw
-        import tqdm
+if (comm_rank == 0) and (args.n_test != 0):
+    print("Testing we can load all particles")
+    import swiftsimio as sw
+    import tqdm
 
-        # Load the FOF file
-        fof = sw.load(args.output_basename + ".hdf5")
-        min_pos = fof.fof_groups.centres - fof.fof_groups.radii[:, None]
-        max_pos = fof.fof_groups.centres + fof.fof_groups.radii[:, None]
+    # Load the FOF file
+    fof = sw.load(args.output_basename + ".hdf5")
+    min_pos = fof.fof_groups.centres - fof.fof_groups.radii[:, None]
+    max_pos = fof.fof_groups.centres + fof.fof_groups.radii[:, None]
 
-        n_test = args.n_test if args.n_test != -1 else fof.fof_groups.sizes.shape[0]
-        for i_fof in tqdm.tqdm(range(n_test)):
+    n_test = args.n_test if args.n_test != -1 else fof.fof_groups.sizes.shape[0]
+    to_test = np.random.choice(np.arange(fof.fof_groups.sizes.shape[0]), n_test, replace=False)
+    for i_fof in tqdm.tqdm(to_test):
 
-            # Create mask and load data
-            snap_filename = args.snap_basename + ".hdf5"
-            mask = sw.mask(snap_filename)
-            load_region = [
-                [min_pos[i_fof, 0], max_pos[i_fof, 0]],
-                [min_pos[i_fof, 1], max_pos[i_fof, 1]],
-                [min_pos[i_fof, 2], max_pos[i_fof, 2]],
-            ]
-            mask.constrain_spatial(load_region)
-            snap = sw.load(snap_filename, mask=mask)
+        # Create mask and load data
+        snap_filename = args.snap_basename + ".hdf5"
+        mask = sw.mask(snap_filename)
+        load_region = [
+            [min_pos[i_fof, 0], max_pos[i_fof, 0]],
+            [min_pos[i_fof, 1], max_pos[i_fof, 1]],
+            [min_pos[i_fof, 2], max_pos[i_fof, 2]],
+        ]
+        mask.constrain_spatial(load_region)
+        snap = sw.load(snap_filename, mask=mask)
 
-            # Check we loaded all the particles
-            n_total = 0
-            for ptype in ["gas", "dark_matter", "stars", "black_holes"]:
-                fof_id = fof.fof_groups.group_ids[i_fof].value
-                part_fof_ids = getattr(snap, ptype).fofgroup_ids.value
-                n_total += np.sum(part_fof_ids == fof_id)
-            msg = f"Failed for object {i_fof}"
-            assert n_total == fof.fof_groups.sizes[i_fof].value, msg
+        # Check we loaded all the particles
+        n_total = 0
+        for ptype in ["gas", "dark_matter", "stars", "black_holes"]:
+            fof_id = fof.fof_groups.group_ids[i_fof].value
+            part_fof_ids = getattr(snap, ptype).fofgroup_ids.value
+            n_total += np.sum(part_fof_ids == fof_id)
+        msg = f"Failed for object {i_fof}"
+        assert n_total == fof.fof_groups.sizes[i_fof].value, msg

--- a/misc/calculate_fof_radii.py
+++ b/misc/calculate_fof_radii.py
@@ -413,6 +413,8 @@ if (comm_rank == 0) and (not args.single_fof_file):
                 dset.attrs[k] = v
 
     print("New files generated!")
+
+if comm_rank == 0:
     print(f"Took {int(time.time() - start_time)} seconds")
 
 if (comm_rank == 0) and (args.n_test != 0):

--- a/misc/calculate_fof_radii.py
+++ b/misc/calculate_fof_radii.py
@@ -71,7 +71,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--copy-datasets",
-    action='store_true',
+    action="store_true",
     help="Copy datasets from input FoF files (otherwise a link is created)",
 )
 parser.add_argument(
@@ -83,17 +83,17 @@ parser.add_argument(
 )
 parser.add_argument(
     "--single-fof-file",
-    action='store_true',
+    action="store_true",
     help="If there is a single FoF file even though there are distributed snapshots",
 )
 parser.add_argument(
     "--recalculate-sizes",
-    action='store_true',
+    action="store_true",
     help="Whether to calculate the number of particles in each FOF group",
 )
 parser.add_argument(
     "--reset-ids",
-    action='store_true',
+    action="store_true",
     help=(
         "Whether to set the group ids in the FOF catalgoues to 1...N ",
         "(This is required for some runs as there was a bug where the incorrect",
@@ -116,15 +116,15 @@ if comm_rank == 0:
     with h5py.File(fof_filename.format(file_nr=0), "r") as file:
         fof_header = dict(file["Header"].attrs)
         unit_attrs = {
-            'Radii': dict(file["Groups/Centres"].attrs),
-            'Sizes': dict(file["Groups/Sizes"].attrs),
-            'GroupIDs': dict(file["Groups/GroupIDs"].attrs),
+            "Radii": dict(file["Groups/Centres"].attrs),
+            "Sizes": dict(file["Groups/Sizes"].attrs),
+            "GroupIDs": dict(file["Groups/GroupIDs"].attrs),
         }
     with h5py.File(snap_filename.format(file_nr=0), "r") as file:
         snap_header = dict(file["Header"].attrs)
     print(f"Running with {comm_size} ranks")
     for k, v in vars(args).items():
-        print(f'  {k}: {v}')
+        print(f"  {k}: {v}")
     print(f'  nr_files: {fof_header["NumFilesPerSnapshot"][0]}')
 else:
     fof_header = None
@@ -142,6 +142,7 @@ nr_files = fof_header["NumFilesPerSnapshot"][0]
 if args.recalculate_sizes or args.reset_ids:
     assert args.copy_datasets
 
+
 def copy_attrs(src_obj, dst_obj):
     for key, val in src_obj.attrs.items():
         dst_obj.attrs[key] = val
@@ -153,9 +154,9 @@ def copy_object(src_obj, dst_obj, src_filename, prefix="", skip_datasets=False):
         if isinstance(item, h5py.Dataset):
             if skip_datasets and (item.name != "/Header/PartTypeNames"):
                 continue
-            if (item.name == '/Groups/Sizes') and args.recalculate_sizes:
+            if (item.name == "/Groups/Sizes") and args.recalculate_sizes:
                 continue
-            if (item.name == '/Groups/GroupIDs') and args.reset_ids:
+            if (item.name == "/Groups/GroupIDs") and args.reset_ids:
                 continue
             if args.copy_datasets:
                 src_obj.copy(name, dst_obj)
@@ -402,7 +403,9 @@ if (comm_rank == 0) and (args.n_test != 0):
     max_pos = fof.fof_groups.centres + fof.fof_groups.radii[:, None]
 
     n_test = args.n_test if args.n_test != -1 else fof.fof_groups.sizes.shape[0]
-    to_test = np.random.choice(np.arange(fof.fof_groups.sizes.shape[0]), n_test, replace=False)
+    to_test = np.random.choice(
+        np.arange(fof.fof_groups.sizes.shape[0]), n_test, replace=False
+    )
     for i_fof in tqdm.tqdm(to_test):
 
         # Create mask and load data

--- a/misc/calculate_fof_radii.py
+++ b/misc/calculate_fof_radii.py
@@ -126,8 +126,8 @@ if comm_rank == 0:
             "Sizes": dict(file["Groups/Sizes"].attrs),
             "GroupIDs": dict(file["Groups/GroupIDs"].attrs),
         }
-        desc = 'Distance to the particle furthest from the centre'
-        unit_attrs['Radii']['Description'] = desc
+        desc = "Distance to the particle furthest from the centre"
+        unit_attrs["Radii"]["Description"] = desc
     with h5py.File(snap_filename.format(file_nr=0), "r") as file:
         snap_header = dict(file["Header"].attrs)
     print(f"Running with {comm_size} ranks")
@@ -252,7 +252,7 @@ if args.recalculate_centres:
         # Load particle positions and their FOF IDs
         part_pos = snap_file.read(f"PartType{ptype}/Coordinates")
         part_fof_ids = snap_file.read(f"PartType{ptype}/FOFGroupIDs")
-        mass_field = 'DynamicalMasses' if ptype == 5 else 'Masses'
+        mass_field = "DynamicalMasses" if ptype == 5 else "Masses"
         part_mass = snap_file.read(f"PartType{ptype}/{mass_field}")
 
         # Ignore particles which aren't part of a FOF group
@@ -277,7 +277,9 @@ if args.recalculate_centres:
         tmp_part_pos = part_pos[part_origin[:, 0] == -1]
         tmp_idx = idx[part_origin[:, 0] == -1]
         assert np.all(tmp_part_pos >= 0)
-        psort.reduce_elements(fof_origin, tmp_part_pos, tmp_idx, op=np.maximum, comm=comm)
+        psort.reduce_elements(
+            fof_origin, tmp_part_pos, tmp_idx, op=np.maximum, comm=comm
+        )
         del tmp_part_pos, tmp_idx
 
         # Get the current FOF origin for each particle


### PR DESCRIPTION
Update the script we have for calculating FOF radii. Added functionality:
- Run on a single (non-distributed) FoF catalogue
- Recalcualte the sizes of the FOF groups
- Set the IDs of the FOF groups as 1..N
- Random selection of halos for testing instead of first N objects

TODO:
- [x] Recalculate CoM
- [x] Delete `fof_radii_script` soap branch