### PR TITLE
Allow pc apertures

### DIFF
--- a/SOAP/particle_selection/aperture_properties.py
+++ b/SOAP/particle_selection/aperture_properties.py
@@ -3640,8 +3640,12 @@ class ApertureProperties(HaloProperty):
         self.inclusive = inclusive
 
         if self.aperture_physical_radius_kpc is not None:
-            aperture_name = f"{self.aperture_physical_radius_kpc:.0f}kpc"
             self.physical_radius_mpc = 0.001 * self.aperture_physical_radius_kpc
+            assert self.aperture_physical_radius_kpc >= 0.001
+            if self.aperture_physical_radius_kpc < 1:
+                aperture_name = f"{1000*self.aperture_physical_radius_kpc:.0f}pc"
+            else:
+                aperture_name = f"{self.aperture_physical_radius_kpc:.0f}kpc"
         else:
             prop = self.aperture_property[0].split("/")[-1]
             assert self.aperture_property[0].split("/")[0] == "BoundSubhalo"

--- a/SOAP/particle_selection/projected_aperture_properties.py
+++ b/SOAP/particle_selection/projected_aperture_properties.py
@@ -1743,8 +1743,12 @@ class ProjectedApertureProperties(HaloProperty):
         self.boxsize = cellgrid.boxsize
 
         if self.aperture_physical_radius_kpc is not None:
-            aperture_name = f"{self.aperture_physical_radius_kpc:.0f}kpc"
             self.physical_radius_mpc = 0.001 * self.aperture_physical_radius_kpc
+            assert self.aperture_physical_radius_kpc >= 0.001
+            if self.aperture_physical_radius_kpc < 1:
+                aperture_name = f"{1000*self.aperture_physical_radius_kpc:.0f}pc"
+            else:
+                aperture_name = f"{self.aperture_physical_radius_kpc:.0f}kpc"
         else:
             prop = self.aperture_property[0].split("/")[-1]
             multiplier = self.aperture_property[1]

--- a/SOAP/property_table.py
+++ b/SOAP/property_table.py
@@ -5093,7 +5093,11 @@ Group name (HDF5) & Group name (swiftsimio) & Inclusive? & Filter \\\\
         apertures = self.parameters.parameters.get("ApertureProperties", {})
         for _, variation in apertures.get("variations", {}).items():
             if "radius_in_kpc" in variation:
-                aperture_name = f'{int(variation["radius_in_kpc"])}kpc'
+                radius_in_kpc = variation["radius_in_kpc"]
+                if radius_in_kpc < 1:
+                    aperture_name = f'{int(radius_in_kpc*1000)}pc'
+                else:
+                    aperture_name = f'{int(radius_in_kpc)}kpc'
             else:
                 prop = variation["property"].split("/")[-1]
                 multiplier = variation.get("radius_multiple", 1)
@@ -5126,7 +5130,11 @@ Group name (HDF5) & Group name (swiftsimio) & Inclusive? & Filter \\\\
         apertures = self.parameters.parameters.get("ProjectedApertureProperties", {})
         for _, variation in apertures.get("variations", {}).items():
             if "radius_in_kpc" in variation:
-                aperture_name = f'{int(variation["radius_in_kpc"])}kpc'
+                radius_in_kpc = variation["radius_in_kpc"]
+                if radius_in_kpc < 1:
+                    aperture_name = f'{int(radius_in_kpc*1000)}pc'
+                else:
+                    aperture_name = f'{int(radius_in_kpc)}kpc'
             else:
                 prop = variation["property"].split("/")[-1]
                 multiplier = variation.get("radius_multiple", 1)

--- a/SOAP/property_table.py
+++ b/SOAP/property_table.py
@@ -5095,9 +5095,9 @@ Group name (HDF5) & Group name (swiftsimio) & Inclusive? & Filter \\\\
             if "radius_in_kpc" in variation:
                 radius_in_kpc = variation["radius_in_kpc"]
                 if radius_in_kpc < 1:
-                    aperture_name = f'{int(radius_in_kpc*1000)}pc'
+                    aperture_name = f"{int(radius_in_kpc*1000)}pc"
                 else:
-                    aperture_name = f'{int(radius_in_kpc)}kpc'
+                    aperture_name = f"{int(radius_in_kpc)}kpc"
             else:
                 prop = variation["property"].split("/")[-1]
                 multiplier = variation.get("radius_multiple", 1)
@@ -5132,9 +5132,9 @@ Group name (HDF5) & Group name (swiftsimio) & Inclusive? & Filter \\\\
             if "radius_in_kpc" in variation:
                 radius_in_kpc = variation["radius_in_kpc"]
                 if radius_in_kpc < 1:
-                    aperture_name = f'{int(radius_in_kpc*1000)}pc'
+                    aperture_name = f"{int(radius_in_kpc*1000)}pc"
                 else:
-                    aperture_name = f'{int(radius_in_kpc)}kpc'
+                    aperture_name = f"{int(radius_in_kpc)}kpc"
             else:
                 prop = variation["property"].split("/")[-1]
                 multiplier = variation.get("radius_multiple", 1)


### PR DESCRIPTION
For colibre we have enabled some apertures smaller than 1kpc. These were all being written to a group called `0kpc`, e.g. both the 300pc and 100pc apertures were written to the same place. This PR allows for apertures smaller than 1kpc. I also added a check so apertures can't be smaller than 1 pc.