### PR TITLE
Add comoving information to membership file

### DIFF
--- a/SOAP/group_membership.py
+++ b/SOAP/group_membership.py
@@ -110,6 +110,8 @@ def process_particle_type(
         "U_T exponent": [0.0],
         "a-scale exponent": [0.0],
         "h-scale exponent": [0.0],
+        "Property can be converted to comoving": [0],
+        "Value stored as physical": [1],
     }
     attrs = {
         "GroupNr_bound": {

--- a/compression/make_virtual_snapshot.py
+++ b/compression/make_virtual_snapshot.py
@@ -18,38 +18,26 @@ def make_virtual_snapshot(snapshot, membership, output_file, snap_nr):
     dset_dtype = {}
     with h5py.File(filename, "r") as infile:
         for ptype in range(7):
-            if not f'PartType{ptype}' in infile:
+            if not f"PartType{ptype}" in infile:
                 continue
-            dset_attrs[f'PartType{ptype}'] = {}
-            dset_dtype[f'PartType{ptype}'] = {}
-            for dset in infile[f'PartType{ptype}'].keys():
-                attrs = dict(infile[f'PartType{ptype}/{dset}'].attrs)
-                dtype = infile[f'PartType{ptype}/{dset}'].dtype
+            dset_attrs[f"PartType{ptype}"] = {}
+            dset_dtype[f"PartType{ptype}"] = {}
+            for dset in infile[f"PartType{ptype}"].keys():
+                attrs = dict(infile[f"PartType{ptype}/{dset}"].attrs)
+                dtype = infile[f"PartType{ptype}/{dset}"].dtype
 
                 # Some membership files are missing these attributes
-                if not 'Value stored as physical' in attrs:
-                    print(f'Setting comoving attrs for PartType{ptype}/{dset}')
-                    attrs['Value stored as physical'] = [1]
+                if not "Value stored as physical" in attrs:
+                    print(f"Setting comoving attrs for PartType{ptype}/{dset}")
+                    attrs["Value stored as physical"] = [1]
                     attrs["Property can be converted to comoving"] = [0]
 
                 # Add a flag that these are stored in the membership files
                 attrs["Auxilary file"] = [1]
 
                 # Store the values we need for later
-                dset_attrs[f'PartType{ptype}'][dset] = attrs
-                dset_dtype[f'PartType{ptype}'][dset] = dtype
-
-    # TODO: Remove
-    # Check which datasets already exist in the snapshot
-    # dset_in_snap = {}
-    # with h5py.File(snapshot, "r") as infile:
-    #     for ptype in range(7):
-    #         if not f'PartType{ptype}' in dset_attrs:
-    #             continue
-    #         dset_in_snap[f'PartType{ptype}'] = []
-    #         for dset in dset_attrs:
-    #             if dset in infile[f'PartType{ptype}']:
-    #                 dset_in_snap[f'PartType{ptype}'].append(dset)
+                dset_attrs[f"PartType{ptype}"][dset] = attrs
+                dset_dtype[f"PartType{ptype}"][dset] = dtype
 
     # Copy the input virtual snapshot to the output
     shutil.copyfile(snapshot, output_file)
@@ -105,9 +93,7 @@ def make_virtual_snapshot(snapshot, membership, output_file, snap_nr):
         # already exist in the snapshot
         for dset, attrs in dset_attrs[f"PartType{ptype}"].items():
             if f"PartType{ptype}/{dset}" in outfile:
-                outfile.move(
-                    f"PartType{ptype}/{dset}", f"PartType{ptype}/{dset}_snap"
-                )
+                outfile.move(f"PartType{ptype}/{dset}", f"PartType{ptype}/{dset}_snap")
             outfile.create_virtual_dataset(
                 f"PartType{ptype}/{dset}", layouts[dset], fillvalue=-999
             )
@@ -115,10 +101,10 @@ def make_virtual_snapshot(snapshot, membership, output_file, snap_nr):
                 outfile[f"PartType{ptype}/{dset}"].attrs[k] = v
 
             # Copy GroupNr_bound to HaloCatalogueIndex, since that is the name in SOAP
-            if dset == 'GroupNr_bound':
+            if dset == "GroupNr_bound":
                 outfile.create_virtual_dataset(
                     f"PartType{ptype}/HaloCatalogueIndex",
-                    layouts['GroupNr_bound'],
+                    layouts["GroupNr_bound"],
                     fillvalue=-999,
                 )
                 for k, v in outfile[f"PartType{ptype}/GroupNr_bound"].attrs.items():
@@ -136,9 +122,9 @@ if __name__ == "__main__":
     # For description of parameters run the following: $ python make_virtual_snapshot.py --help
     parser = argparse.ArgumentParser(
         description=(
-            "Link SWIFT snapshots with SWIFT auxilary snapshots (snapshot-like
-            files with the same number of particles in the same order as the
-            snapshot, but with less metadata), such as the SOAP memberships"
+            "Link SWIFT snapshots with SWIFT auxilary snapshots (snapshot-like"
+            "files with the same number of particles in the same order as the"
+            "snapshot, but with less metadata), such as the SOAP memberships"
         )
     )
     parser.add_argument(

--- a/compression/make_virtual_snapshot.py
+++ b/compression/make_virtual_snapshot.py
@@ -96,7 +96,9 @@ def make_virtual_snapshot(snapshot, membership, output_file, snap_nr):
             n_part = count[f"PartType{ptype}"]
             for dset in dset_attrs[f"PartType{ptype}"]:
                 layouts[dset][offset : offset + n_part] = h5py.VirtualSource(
-                    filename, f"PartType{ptype}/{dset}", shape=shape[f"PartType{ptype}"][dset]
+                    filename,
+                    f"PartType{ptype}/{dset}",
+                    shape=shape[f"PartType{ptype}"][dset],
                 )
             offset += n_part
 

--- a/compression/update_vds_paths.py
+++ b/compression/update_vds_paths.py
@@ -83,16 +83,21 @@ def update_virtual_snapshot_paths(filename, snapshot_dir=None, membership_dir=No
     for dset in all_datasets:
         if dset.is_virtual:
             name = dset.name.split("/")[-1]
-            # Data comes from the membership files
-            if name in (
+            # Check if the dataset comes from a membership file
+            if dset.attrs.get('Auxilary file', [0])[0] == 1:
+                if membership_dir is not None:
+                    update_vds_paths(dset, replace_membership_path)
+            # Catch old datasets which didn't have the "Auxilary file" set
+            elif name in (
                 "GroupNr_all",
                 "GroupNr_bound",
                 "Rank_bound",
                 "HaloCatalogueIndex",
+                "SpecificPotentialEnergies",
             ):
                 if membership_dir is not None:
                     update_vds_paths(dset, replace_membership_path)
-            # FOF IDs come from membership files
+            # Catch old case of FOF IDs from membership files
             elif (name == "FOFGroupIDs") and ("PartType1/FOFGroupIDs_old" in f):
                 if membership_dir is not None:
                     update_vds_paths(dset, replace_membership_path)

--- a/compression/update_vds_paths.py
+++ b/compression/update_vds_paths.py
@@ -84,7 +84,7 @@ def update_virtual_snapshot_paths(filename, snapshot_dir=None, membership_dir=No
         if dset.is_virtual:
             name = dset.name.split("/")[-1]
             # Check if the dataset comes from a membership file
-            if dset.attrs.get('Auxilary file', [0])[0] == 1:
+            if dset.attrs.get("Auxilary file", [0])[0] == 1:
                 if membership_dir is not None:
                     update_vds_paths(dset, replace_membership_path)
             # Catch old datasets which didn't have the "Auxilary file" set


### PR DESCRIPTION
Thanks to @VictorForouhar for spotting that the virtual snapshots have the wrong unit attributes set for the datasets in the membership files.

Changes
- Update the group membership script to add comoving information to the datasets it creates
- Update the virtual file creation script to copy unit attributes from the membership files
- Update the virtual file creation script to work with any "snapshot-like" file (e.g. regenerated xrays) 