### PR TITLE
Squash bug when copying small apertures

### DIFF
--- a/SOAP/particle_selection/aperture_properties.py
+++ b/SOAP/particle_selection/aperture_properties.py
@@ -3777,7 +3777,12 @@ class ApertureProperties(HaloProperty):
                     skip_gt_enclose_radius = True
                     # Skip if this halo has a filter
                     if do_calculation[self.halo_filter]:
-                        prev_group_name = f"ExclusiveSphere/{r_previous_kpc:.0f}kpc"
+                        if r_previous_kpc < 1:
+                            prev_group_name = (
+                                f"ExclusiveSphere/{1000*r_previous_kpc:.0f}pc"
+                            )
+                        else:
+                            prev_group_name = f"ExclusiveSphere/{r_previous_kpc:.0f}kpc"
                         for name, prop in self.property_list.items():
                             outputname = prop.name
                             # Skip if this property is disabled in the parameter file

--- a/SOAP/particle_selection/projected_aperture_properties.py
+++ b/SOAP/particle_selection/projected_aperture_properties.py
@@ -1870,7 +1870,12 @@ class ProjectedApertureProperties(HaloProperty):
                 )
 
                 if skip_gt_enclose_radius:
-                    prev_group_name = f"ProjectedAperture/{r_previous_kpc:.0f}kpc"
+                    if r_previous_kpc < 1:
+                        prev_group_name = (
+                            f"ProjectedAperture/{1000*r_previous_kpc:.0f}pc"
+                        )
+                    else:
+                        prev_group_name = f"ProjectedAperture/{r_previous_kpc:.0f}kpc"
                     prev_prop = f"{prev_group_name}/{projname}/{outputname}"
                     # Skip if this property has a direct dependence on
                     # aperture size (and so would have a different value)


### PR DESCRIPTION
Squash bug introduced in https://github.com/SWIFTSIM/SOAP/pull/181 where we still looked for `0kpc` apertures when copying values