### PR TITLE
Adjust lustre settings

### DIFF
--- a/SOAP/compute_halo_properties.py
+++ b/SOAP/compute_halo_properties.py
@@ -545,7 +545,7 @@ def compute_halo_properties():
         try:
             os.makedirs(os.path.dirname(args.output_file), exist_ok=True)
         except OSError as e:
-            print(f'Error creating output directory: {e}')
+            print(f"Error creating output directory: {e}")
             comm_world.Abort(1)
     comm_world.barrier()
 
@@ -587,7 +587,7 @@ def compute_halo_properties():
             try:
                 os.makedirs(scratch_file_dir, exist_ok=True)
             except OSError as e:
-                print(f'Error creating scratch directory: {e}')
+                print(f"Error creating scratch directory: {e}")
                 comm_world.Abort(1)
     comm_world.barrier()
 

--- a/SOAP/compute_halo_properties.py
+++ b/SOAP/compute_halo_properties.py
@@ -542,7 +542,11 @@ def compute_halo_properties():
 
     # Ensure output dir exists
     if comm_world_rank == 0:
-        lustre.ensure_output_dir(args.output_file)
+        try:
+            os.makedirs(os.path.dirname(args.output_file), exist_ok=True)
+        except OSError as e:
+            print(f'Error creating output directory: {e}')
+            comm_world.Abort(1)
     comm_world.barrier()
 
     # Read in the halo catalogue:
@@ -581,9 +585,10 @@ def compute_halo_properties():
             scratch_file_name = scratch_file_format % {"file_nr": file_nr}
             scratch_file_dir = os.path.dirname(scratch_file_name)
             try:
-                os.makedirs(scratch_file_dir)
-            except OSError:
-                pass
+                os.makedirs(scratch_file_dir, exist_ok=True)
+            except OSError as e:
+                print(f'Error creating scratch directory: {e}')
+                comm_world.Abort(1)
     comm_world.barrier()
 
     # Report initial set-up time

--- a/SOAP/core/combine_chunks.py
+++ b/SOAP/core/combine_chunks.py
@@ -14,7 +14,7 @@ from virgo.util.partial_formatter import PartialFormatter
 from SOAP.catalogue_readers import read_hbtplus
 from SOAP.property_calculation.subhalo_rank import compute_subhalo_rank
 from SOAP.property_table import PropertyTable
-from . import swift_units
+from . import lustre, swift_units
 from .mpi_timer import MPITimer
 
 
@@ -207,6 +207,9 @@ def combine_chunks(
     with MPITimer("Creating output file", comm_world):
         output_file = sub_snapnum(args.output_file, args.snapshot_nr)
         if comm_world.Get_rank() == 0:
+            # Set striping on the file
+            lustre.setstripe(output_file, 32, -1)
+
             # Create the file
             outfile = h5py.File(output_file, "w")
 

--- a/SOAP/core/combine_chunks.py
+++ b/SOAP/core/combine_chunks.py
@@ -208,7 +208,7 @@ def combine_chunks(
         output_file = sub_snapnum(args.output_file, args.snapshot_nr)
         if comm_world.Get_rank() == 0:
             # Set striping on the file
-            lustre.setstripe(output_file, 32, -1)
+            lustre.setstripe(output_file)
 
             # Create the file
             outfile = h5py.File(output_file, "w")

--- a/SOAP/core/lustre.py
+++ b/SOAP/core/lustre.py
@@ -4,7 +4,7 @@ import subprocess
 import os
 
 
-def setstripe(filename, stripe_size, stripe_count):
+def setstripe(filename, stripe_size=32, stripe_count=32):
     """
     Try to set Lustre striping on a file
     """
@@ -13,6 +13,11 @@ def setstripe(filename, stripe_size, stripe_count):
         os.remove(filename)
     except FileNotFoundError:
         pass
+
+    # Only set striping for snap8 on cosma
+    if not filename.startswith('/snap8/scratch'):
+        print(f'Not setting lustre striping on {filename}')
+        return
 
     args = [
         "lfs",

--- a/SOAP/core/lustre.py
+++ b/SOAP/core/lustre.py
@@ -4,34 +4,27 @@ import subprocess
 import os
 
 
-def setstripe(dirname, stripe_size, stripe_count):
+def setstripe(filename, stripe_size, stripe_count):
     """
-    Try to set Lustre striping on a directory
+    Try to set Lustre striping on a file
     """
+    # Remove file if it already exists (or lfs will error)
+    try:
+        os.remove(filename)
+    except FileNotFoundError:
+        pass
+
     args = [
         "lfs",
         "setstripe",
-        "--stripe-count=%d" % stripe_count,
-        "--stripe-size=%dM" % stripe_size,
-        dirname,
+        f"--stripe-count={stripe_count}",
+        f"--stripe-size={stripe_size}M",
+        filename,
     ]
     try:
         subprocess.run(args)
     except (FileNotFoundError, subprocess.CalledProcessError):
         # if the 'lfs' command is not available, this will generate a
         # FileNotFoundError
-        print("WARNING: failed to set lustre striping on %s" % dirname)
+        print(f"WARNING: failed to set lustre striping on {filename}")
 
-
-def ensure_output_dir(filename):
-
-    # Try to ensure the directory exists
-    dirname = os.path.dirname(filename)
-    try:
-        os.makedirs(dirname, exist_ok=True)
-    except OSError:
-        # TODO: Raise this, catch it, and throw MPI Abort
-        pass
-
-    # Try to set striping
-    setstripe(dirname, 32, -1)

--- a/SOAP/core/lustre.py
+++ b/SOAP/core/lustre.py
@@ -27,4 +27,3 @@ def setstripe(filename, stripe_size, stripe_count):
         # if the 'lfs' command is not available, this will generate a
         # FileNotFoundError
         print(f"WARNING: failed to set lustre striping on {filename}")
-

--- a/SOAP/core/lustre.py
+++ b/SOAP/core/lustre.py
@@ -15,8 +15,8 @@ def setstripe(filename, stripe_size=32, stripe_count=32):
         pass
 
     # Only set striping for snap8 on cosma
-    if not filename.startswith('/snap8/scratch'):
-        print(f'Not setting lustre striping on {filename}')
+    if not filename.startswith("/snap8/scratch"):
+        print(f"Not setting lustre striping on {filename}")
         return
 
     args = [

--- a/SOAP/group_membership.py
+++ b/SOAP/group_membership.py
@@ -209,7 +209,7 @@ def main():
         try:
             os.makedirs(os.path.dirname(output_filename), exist_ok=True)
         except OSError as e:
-            print(f'Error creating output directory: {e}')
+            print(f"Error creating output directory: {e}")
             comm.Abort(1)
     comm.barrier()
 

--- a/SOAP/group_membership.py
+++ b/SOAP/group_membership.py
@@ -10,7 +10,7 @@ import virgo.mpi.parallel_hdf5 as phdf5
 import virgo.mpi.parallel_sort as psort
 from virgo.util.partial_formatter import PartialFormatter
 
-from SOAP.core import combine_args, lustre, swift_units
+from SOAP.core import combine_args, swift_units
 from SOAP.catalogue_readers import read_vr
 from SOAP.catalogue_readers import read_hbtplus
 from SOAP.catalogue_readers import read_subfind
@@ -206,7 +206,11 @@ def main():
 
     # Ensure output dir exists
     if comm_rank == 0:
-        lustre.ensure_output_dir(output_filename)
+        try:
+            os.makedirs(os.path.dirname(output_filename), exist_ok=True)
+        except OSError as e:
+            print(f'Error creating output directory: {e}')
+            comm.Abort(1)
     comm.barrier()
 
     # Find group number for each particle ID in the halo finder output

--- a/misc/match_group_membership.py
+++ b/misc/match_group_membership.py
@@ -379,7 +379,7 @@ if __name__ == "__main__":
     # Log the arguments
     if comm_rank == 0:
         for k, v in vars(args).items():
-            print(f'  {k}: {v}')
+            print(f"  {k}: {v}")
 
     mpi_print("Loading data from simulation 1", comm_rank)
     data_1 = load_particle_data(

--- a/misc/recalculate_xrays.py
+++ b/misc/recalculate_xrays.py
@@ -1,3 +1,5 @@
+import os
+
 import h5py
 from mpi4py import MPI
 import numpy as np
@@ -5,7 +7,7 @@ import virgo.mpi.parallel_hdf5 as phdf5
 import virgo.mpi.parallel_sort as psort
 from virgo.util.partial_formatter import PartialFormatter
 
-from SOAP.core import lustre, swift_units
+from SOAP.core import swift_units
 import xray_calculator
 
 comm = MPI.COMM_WORLD
@@ -213,7 +215,11 @@ if __name__ == "__main__":
 
     # Ensure output dir exists
     if comm_rank == 0:
-        lustre.ensure_output_dir(output_filename)
+        try:
+            os.makedirs(os.path.dirname(output_filename), exist_ok=True)
+        except OSError as e:
+            print(f'Error creating output directory: {e}')
+            comm.Abort(1)
     comm.barrier()
 
     # Load tables on rank 0

--- a/misc/recalculate_xrays.py
+++ b/misc/recalculate_xrays.py
@@ -218,7 +218,7 @@ if __name__ == "__main__":
         try:
             os.makedirs(os.path.dirname(output_filename), exist_ok=True)
         except OSError as e:
-            print(f'Error creating output directory: {e}')
+            print(f"Error creating output directory: {e}")
             comm.Abort(1)
     comm.barrier()
 

--- a/scripts/COLIBRE/compress_group_membership.sh
+++ b/scripts/COLIBRE/compress_group_membership.sh
@@ -60,7 +60,6 @@ outbase="${output_dir}/${sim}/SOAP/"
 # Create the output folder if it does not exist
 outdir="${outbase}/membership_${snapnum}"
 mkdir -p "${outdir}"
-lfs setstripe --stripe-count=-1 --stripe-size=32M "${outdir}"
 
 # Uncompressed membership file basename
 input_filename="${inbase}/membership_${snapnum}/membership_${snapnum}"

--- a/scripts/FLAMINGO/L1000N0900/compress_group_membership_L1000N0900.sh
+++ b/scripts/FLAMINGO/L1000N0900/compress_group_membership_L1000N0900.sh
@@ -69,7 +69,6 @@ outbase="${output_dir}/${sim}/SOAP/${halo_finder}/"
 # Create the output folder if it does not exist
 outdir="${outbase}/membership_${snapnum}"
 mkdir -p "${outdir}"
-lfs setstripe --stripe-count=-1 --stripe-size=32M "${outdir}"
 
 # Uncompressed membership file basename
 input_filename="${inbase}/membership_${snapnum}/membership_${snapnum}"

--- a/scripts/FLAMINGO/L1000N1800/compress_group_membership_L1000N1800.sh
+++ b/scripts/FLAMINGO/L1000N1800/compress_group_membership_L1000N1800.sh
@@ -69,7 +69,6 @@ outbase="${output_dir}/${sim}/SOAP/${halo_finder}/"
 # Create the output folder if it does not exist
 outdir="${outbase}/membership_${snapnum}"
 mkdir -p "${outdir}"
-lfs setstripe --stripe-count=-1 --stripe-size=32M "${outdir}"
 
 # Uncompressed membership file basename
 input_filename="${inbase}/membership_${snapnum}/membership_${snapnum}"


### PR DESCRIPTION
I ended up looking into SOAP's lustre setting as a result of the recent snap8 crash.
- We are currently spreading each membership chunk file across all OSTs. I don't see a reason to do this (SWIFT outputs snapshots with `stripe-count=1`). I have just disabled the lustre settings for the membership files.
- The uncompressed SOAP catalogues are so large that they do need to be spread across OSTs. However, we were setting the stripe setting of the output directory, and I have changed this to setting the stripe of the output file itself. I think this is safer, as other things could end up getting written to the output directory for which we do not want striping. 
- I did spend an afternoon looking into https://github.com/SWIFTSIM/SOAP/issues/30, but couldn't find a solution. It looks like `h5py` still doesn't provide the low level functions we would need.

@jchelly could you please let me know if this sounds sensible to you?