### PR TITLE
Sink compatibility

### DIFF
--- a/SOAP/particle_selection/halo_properties.py
+++ b/SOAP/particle_selection/halo_properties.py
@@ -25,6 +25,7 @@ class HaloProperty:
         self.softening_of_parttype = {
             "PartType0": cellgrid.baryon_softening,
             "PartType1": cellgrid.dark_matter_softening,
+            "PartType3": cellgrid.baryon_softening,
             "PartType4": cellgrid.baryon_softening,
             "PartType5": cellgrid.baryon_softening,
             "PartType6": cellgrid.nu_softening,

--- a/SOAP/particle_selection/subhalo_properties.py
+++ b/SOAP/particle_selection/subhalo_properties.py
@@ -180,6 +180,14 @@ class SubhaloParticleData:
         return self.types == 1
 
     @lazy_property
+    def sink_mask_sh(self) -> NDArray[bool]:
+        """
+        Mask used to mask out sink particles that belong to this subhalo in
+        arrays containing all particles, e.g. self.mass.
+        """
+        return self.types == 3
+
+    @lazy_property
     def star_mask_sh(self) -> NDArray[bool]:
         """
         Mask used to mask out star particles that belong to this subhalo in
@@ -216,6 +224,13 @@ class SubhaloParticleData:
         Number of dark matter particles in the subhalo.
         """
         return self.dm_mask_sh.sum()
+
+    @lazy_property
+    def Nsink(self) -> int:
+        """
+        Number of sink particles in the subhalo.
+        """
+        return self.sink_mask_sh.sum()
 
     @lazy_property
     def Nstar(self) -> int:
@@ -2540,6 +2555,7 @@ class SubhaloProperties(HaloProperty):
         self.particle_properties = {
             "PartType0": ["Coordinates", "Masses", "Velocities", "GroupNr_bound"],
             "PartType1": ["Coordinates", "Masses", "Velocities", "GroupNr_bound"],
+            "PartType3": ["Coordinates", "Masses", "Velocities", "GroupNr_bound"],
             "PartType4": ["Coordinates", "Masses", "Velocities", "GroupNr_bound"],
             "PartType5": [
                 "Coordinates",
@@ -2603,6 +2619,7 @@ class SubhaloProperties(HaloProperty):
             {
                 "BoundSubhalo/NumberOfDarkMatterParticles": part_props.Ndm,
                 "BoundSubhalo/NumberOfGasParticles": part_props.Ngas,
+                "BoundSubhalo/NumberOfSinkParticles": part_props.Nsink,
                 "BoundSubhalo/NumberOfStarParticles": part_props.Nstar,
                 "BoundSubhalo/NumberOfBlackHoleParticles": part_props.Nbh,
             },
@@ -2612,7 +2629,7 @@ class SubhaloProperties(HaloProperty):
         # If not, we need to try again with a larger search radius.
         # For HBT this should not happen since we use the radius of the most distant
         # bound particle.
-        Ntot = part_props.Ngas + part_props.Ndm + part_props.Nstar + part_props.Nbh
+        Ntot = part_props.Ngas + part_props.Ndm + part_props.Nsink + part_props.Nstar + part_props.Nbh
         Nexpected = input_halo["nr_bound_part"]
         if Ntot < Nexpected:
             # Try again with a larger search radius


### PR DESCRIPTION
Hi - here's a branch with some very simple changes to add basic sink particle compatibility in SOAP.

The group membership part of SOAP seems to cope fine with a new particle type, but I needed to add these bits in such that we arrive at the correct number of particles bound to haloes.

I'm sure there will be much more optional stuff to add in future, but for now please let me know if I've missed anything critical that will cause problems now that a new particle type has been introduced!

