### PR TITLE
Parameter file parsing

### DIFF
--- a/SOAP/compute_halo_properties.py
+++ b/SOAP/compute_halo_properties.py
@@ -151,6 +151,11 @@ def compute_halo_properties():
         parameter_file = ParameterFile(
             file_name=args.config_filename, snipshot=args.snipshot
         )
+        try:
+            parameter_file.check_schema()
+        except ValueError as e:
+            print(e, flush=True)
+            comm_world.Abort(1)
     else:
         parameter_file = None
     parameter_file = comm_world.bcast(parameter_file)

--- a/SOAP/compute_halo_properties.py
+++ b/SOAP/compute_halo_properties.py
@@ -195,33 +195,7 @@ def compute_halo_properties():
         cold_dense_params["initialised"],
     )
 
-    default_filters = {
-        "general": {
-            "limit": 100,
-            "properties": [
-                "BoundSubhalo/NumberOfDarkMatterParticles",
-                "BoundSubhalo/NumberOfGasParticles",
-                "BoundSubhalo/NumberOfStarParticles",
-                "BoundSubhalo/NumberOfBlackHoleParticles",
-            ],
-            "combine_properties": "sum",
-        },
-        "dm": {
-            "limit": 100,
-            "properties": ["BoundSubhalo/NumberOfDarkMatterParticles"],
-        },
-        "gas": {"limit": 100, "properties": ["BoundSubhalo/NumberOfGasParticles"]},
-        "star": {"limit": 100, "properties": ["BoundSubhalo/NumberOfStarParticles"]},
-        "baryon": {
-            "limit": 100,
-            "properties": [
-                "BoundSubhalo/NumberOfGasParticles",
-                "BoundSubhalo/NumberOfStarParticles",
-            ],
-            "combine_properties": "sum",
-        },
-    }
-    filters = parameter_file.get_filters(default_filters)
+    filters = parameter_file.get_filters()
     category_filter = CategoryFilter(filters, dmo=args.dmo)
 
     # Get the full list of property calculations we can do

--- a/SOAP/compute_halo_properties.py
+++ b/SOAP/compute_halo_properties.py
@@ -246,20 +246,7 @@ def compute_halo_properties():
         )
     )
 
-    SO_variations = parameter_file.get_halo_type_variations(
-        "SOProperties",
-        {
-            "200_mean": {"value": 200.0, "type": "mean"},
-            "50_crit": {"value": 50.0, "type": "crit"},
-            "100_crit": {"value": 100.0, "type": "crit"},
-            "200_crit": {"value": 200.0, "type": "crit"},
-            "500_crit": {"value": 500.0, "type": "crit"},
-            "1000_crit": {"value": 1000.0, "type": "crit"},
-            "2500_crit": {"value": 2500.0, "type": "crit"},
-            "BN98": {"value": 0.0, "type": "BN98"},
-            "5xR500_crit": {"value": 500.0, "type": "crit", "radius_multiple": 5.0},
-        },
-    )
+    SO_variations = parameter_file.get_halo_type_variations("SOProperties")
     # first add non radius multiples to make sure the radius multiples can be
     # computed
     for variation in SO_variations:
@@ -314,27 +301,7 @@ def compute_halo_properties():
                 )
             )
 
-    aperture_variations = parameter_file.get_halo_type_variations(
-        "ApertureProperties",
-        {
-            "inclusive_10_kpc": {"radius_in_kpc": 10.0, "inclusive": True},
-            "inclusive_30_kpc": {"radius_in_kpc": 30.0, "inclusive": True},
-            "inclusive_50_kpc": {"radius_in_kpc": 50.0, "inclusive": True},
-            "inclusive_100_kpc": {"radius_in_kpc": 100.0, "inclusive": True},
-            "inclusive_300_kpc": {"radius_in_kpc": 300.0, "inclusive": True},
-            "inclusive_500_kpc": {"radius_in_kpc": 500.0, "inclusive": True},
-            "inclusive_1000_kpc": {"radius_in_kpc": 1000.0, "inclusive": True},
-            "inclusive_3000_kpc": {"radius_in_kpc": 3000.0, "inclusive": True},
-            "exclusive_10_kpc": {"radius_in_kpc": 10.0, "inclusive": False},
-            "exclusive_30_kpc": {"radius_in_kpc": 30.0, "inclusive": False},
-            "exclusive_50_kpc": {"radius_in_kpc": 50.0, "inclusive": False},
-            "exclusive_100_kpc": {"radius_in_kpc": 100.0, "inclusive": False},
-            "exclusive_300_kpc": {"radius_in_kpc": 300.0, "inclusive": False},
-            "exclusive_500_kpc": {"radius_in_kpc": 500.0, "inclusive": False},
-            "exclusive_1000_kpc": {"radius_in_kpc": 1000.0, "inclusive": False},
-            "exclusive_3000_kpc": {"radius_in_kpc": 3000.0, "inclusive": False},
-        },
-    )
+    aperture_variations = parameter_file.get_halo_type_variations("ApertureProperties")
 
     # Sort the aperture variations based on their radii, and create a list
     # of all apertures. This is required since we can skip some of the larger
@@ -440,13 +407,7 @@ def compute_halo_properties():
             )
 
     projected_aperture_variations = parameter_file.get_halo_type_variations(
-        "ProjectedApertureProperties",
-        {
-            "10_kpc": {"radius_in_kpc": 10.0},
-            "30_kpc": {"radius_in_kpc": 30.0},
-            "50_kpc": {"radius_in_kpc": 50.0},
-            "100_kpc": {"radius_in_kpc": 100.0},
-        },
+        "ProjectedApertureProperties"
     )
     # Sort the aperture variations based on their radii, and create a list
     # of all apertures. This is required since we can skip some of the larger
@@ -533,6 +494,7 @@ def compute_halo_properties():
             print("Storing processing time for each property")
         parameter_file.print_unregistered_properties()
         parameter_file.print_invalid_properties(halo_prop_list)
+        parameter_file.print_variation_warnings()
         if not parameter_file.renclose_enabled():
             print(
                 "BoundSubhalo/EncloseRadius is not enabled. This means apertures with r > r_enclose will be calculated explicitly, rather than copying over values from smaller apertures"

--- a/SOAP/core/parameter_file.py
+++ b/SOAP/core/parameter_file.py
@@ -15,6 +15,41 @@ import yaml
 
 from SOAP import property_table
 
+# Known parameter file structure, used by check_schema to flag typos. A value
+# of None means the keys directly under that section are user-named or free-form
+# and are not checked; a set lists the only keys allowed directly under that
+# section. Add a key here when a new option is introduced.
+_ALLOWED_KEYS = {
+    "Parameters": None,
+    "Snapshots": {"filename", "fof_filename"},
+    "HaloFinder": {
+        "type",
+        "filename",
+        "fof_filename",
+        "fof_radius_filename",
+        "read_potential_energies",
+    },
+    "GroupMembership": {"filename"},
+    "ExtraInput": None,
+    "HaloProperties": {"filename", "chunk_dir"},
+    "SubhaloProperties": {"properties"},
+    "ApertureProperties": {"properties", "variations"},
+    "ProjectedApertureProperties": {"properties", "variations"},
+    "SOProperties": {"properties", "variations"},
+    "aliases": None,
+    "filters": None,
+    "defined_constants": None,
+    "calculations": {
+        "calculate_missing_properties",
+        "min_read_radius_cmpc",
+        "strict_halo_copy",
+        "reduced_snapshots",
+        "recently_heated_gas_filter",
+        "cold_dense_gas_filter",
+        "separate_chunks",
+    },
+}
+
 
 class ParameterFile:
     """
@@ -325,6 +360,26 @@ class ParameterFile:
         """
         for warning in self.variation_warnings:
             print(warning)
+
+    def check_schema(self) -> None:
+        """
+        Abort if the parameter file has an unrecognised section, or a mistyped
+        key directly under a section which has a fixed set of keys (see
+        _ALLOWED_KEYS). This catches typos which would otherwise be silently
+        ignored. It does not check value types, or keys nested more deeply.
+        """
+        errors = []
+        for section, block in self.parameters.items():
+            if section not in _ALLOWED_KEYS:
+                errors.append(f'unknown section "{section}"')
+            elif _ALLOWED_KEYS[section] is not None and isinstance(block, dict):
+                errors += [
+                    f'unknown key "{section}/{key}"'
+                    for key in block
+                    if key not in _ALLOWED_KEYS[section]
+                ]
+        if errors:
+            raise ValueError("Invalid parameter file: " + "; ".join(errors))
 
     def get_particle_property(self, property_name: str) -> Tuple[str, str]:
         """

--- a/SOAP/core/parameter_file.py
+++ b/SOAP/core/parameter_file.py
@@ -86,6 +86,33 @@ class ParameterFile:
         with open(file_name, "w") as handle:
             yaml.safe_dump(self.parameters, handle)
 
+    def _validate_filter_name(self, filter_name, context: str) -> None:
+        """
+        Check that a filter referenced in the parameter file is one that SOAP
+        can apply.
+
+        The only always-available filter is "basic" (computed for every halo).
+        Any other filter must be defined in the "filters" section of the
+        parameter file; there are no default filters.
+
+        Parameters:
+         - filter_name:
+           The filter as read from the parameter file.
+         - context: str
+           Human readable description of where the filter is used, included in
+           the error message.
+
+        Raises ValueError if the filter is not "basic" and is not defined in the
+        "filters" section.
+        """
+        if filter_name == "basic":
+            return
+        if filter_name not in self.parameters.get("filters", {}):
+            raise ValueError(
+                f'{context} uses filter "{filter_name}" which is not defined in '
+                f'the "filters" section of the parameter file'
+            )
+
     def get_property_filters(self, base_halo_type: str, full_list: List[str]) -> Dict:
         """
         Get a dictionary with the filter that should be applied to each
@@ -148,9 +175,9 @@ class ParameterFile:
                 else:
                     filters[property] = False
             if isinstance(filters[property], str):
-                assert (filters[property] in self.parameters.get("filters", {})) or (
-                    filters[property] == "basic"
-                ), f'Filter "{filters[property]}" is not defined in paramter file'
+                self._validate_filter_name(
+                    filters[property], f"{base_halo_type}/{property}"
+                )
             else:
                 assert filters[property] == False
 
@@ -282,6 +309,13 @@ class ParameterFile:
             section["variations"] = {}
             return {}
 
+        # Check that any filters referenced by the variations are defined
+        for name, variation in section["variations"].items():
+            self._validate_filter_name(
+                variation.get("filter", "basic"),
+                f"{base_halo_type} variation '{name}'",
+            )
+
         return dict(section["variations"])
 
     def print_variation_warnings(self) -> None:
@@ -342,30 +376,17 @@ class ParameterFile:
                 self.aliases = dict()
         return self.aliases
 
-    def get_filters(self, default_filters: Dict) -> Dict:
+    def get_filters(self) -> Dict:
         """
-        Get a dictionary with filters to use for SOAP.
+        Get the category filters defined in the parameter file.
 
-        Parameters:
-         - default_filter: Dict
-           Dictionary with default filters, which are used
-           if no filters are found in the parameter file or if a particular
-           category is missing.
-
-        Returns a dictionary with a threshold value for each category present,
-        the properties to use for the filter, and how to combine the properties
-        if multiple are listed.
+        Returns the contents of the "filters" section, or an empty dictionary if
+        the section is absent. There are no default filters: any filter
+        referenced by a property or a halo type variation must be defined in the
+        parameter file. The only exception is the implicit "basic" filter, which
+        is always computed and is not listed in the "filters" section.
         """
-        filters = dict(default_filters)
-        if "filters" in self.parameters:
-            for category in default_filters:
-                if category in self.parameters["filters"]:
-                    filters[category] = self.parameters["filters"][category]
-                else:
-                    self.parameters["filters"][category] = filters[category]
-        else:
-            self.parameters["filters"] = dict(default_filters)
-        return filters
+        return dict(self.parameters.get("filters", {}))
 
     def get_defined_constants(self) -> Dict:
         """

--- a/SOAP/core/parameter_file.py
+++ b/SOAP/core/parameter_file.py
@@ -65,6 +65,10 @@ class ParameterFile:
 
         self.property_filters = {}
 
+        # Warnings generated while resolving halo type variations, printed later
+        # on a single rank via print_variation_warnings()
+        self.variation_warnings = []
+
     def get_parameters(self) -> Dict:
         """
         Get a copy of the parameter dictionary.
@@ -179,6 +183,11 @@ class ParameterFile:
             # Skip keys which aren't halo types
             if "properties" not in self.parameters[key]:
                 continue
+            # Skip halo types which have a variations key that is an empty dict.
+            # SubhaloProperties never has a variations key, so is still checked.
+            variations = self.parameters[key].get("variations", None)
+            if isinstance(variations, dict) and len(variations) == 0:
+                continue
             # Add all properties to the invalid list
             for prop in self.parameters[key]["properties"]:
                 invalid_properties.add((key, prop))
@@ -200,39 +209,88 @@ class ParameterFile:
             for base_halo_type, prop in invalid_properties:
                 print(f"  {base_halo_type}  {prop}")
 
-    def get_halo_type_variations(
-        self, base_halo_type: str, default_variations: Dict
-    ) -> Dict:
+    def has_enabled_properties(self, base_halo_type: str) -> bool:
+        """
+        Return True if the parameter file enables at least one property for the
+        given halo type, taking the current snapshot/snipshot mode into account.
+        """
+        section = self.parameters.get(base_halo_type) or {}
+        properties = section.get("properties") or {}
+        for value in properties.values():
+            # value may be a dict specifying different behaviour for
+            # snapshots/snipshots
+            if isinstance(value, dict):
+                value = value["snipshot"] if self.snipshot else value["snapshot"]
+            if value:
+                return True
+        return False
+
+    def get_halo_type_variations(self, base_halo_type: str) -> Dict:
         """
         Get a dictionary of variations for the given halo type.
 
-        Different variations are for example bound/unbound SubhaloProperties or
-        aperture properties with different aperture sizes.
+        Different variations are for example aperture properties with different
+        aperture sizes, or spherical overdensities with different definitions.
 
-        If the given halo type is not found in the parameter file, or no
-        variations are specified, the default variations are used.
+        There are no default variations. A missing section, a missing or empty
+        "variations", and a "variations: {}" are all treated identically. The
+        behaviour depends on whether any properties are enabled for the halo
+        type (see has_enabled_properties):
+
+         - No variations, no properties enabled: nothing is computed, no message.
+         - No variations, but properties enabled: nothing is computed, a warning
+           is recorded.
+         - Variations set, no properties enabled, calculate_missing_properties
+           is False: nothing is computed, the variations are cleared and a
+           warning is recorded.
+         - Variations set, no properties enabled, calculate_missing_properties
+           is True: all properties are computed for the variations.
+         - Variations set and properties enabled: the variations are computed.
 
         Parameters:
          - base_halo_type: str
            Halo type identifier in the parameter file, can be one of
-           ApertureProperties, ProjectedApertureProperties, SOProperties
-           or SubhaloProperties.
-         - default_variations: Dict
-           Dictionary with default variations that will be used if the
-           halo type variations are not provided in the parameter file.
+           ApertureProperties, ProjectedApertureProperties or SOProperties.
 
         Returns a dictionary from which different versions of the
         corresponding HaloProperty specialisation can be constructed.
         """
-        if not base_halo_type in self.parameters:
-            self.parameters[base_halo_type] = {}
-        if not "variations" in self.parameters[base_halo_type]:
-            self.parameters[base_halo_type]["variations"] = {}
-            for variation in default_variations:
-                self.parameters[base_halo_type]["variations"][variation] = dict(
-                    default_variations[variation]
+        section = self.parameters.get(base_halo_type)
+        if not isinstance(section, dict):
+            section = {}
+            self.parameters[base_halo_type] = section
+        if not isinstance(section.get("variations"), dict):
+            section["variations"] = {}
+
+        has_variations = len(section["variations"]) > 0
+        has_properties = self.has_enabled_properties(base_halo_type)
+
+        if not has_variations:
+            if has_properties:
+                self.variation_warnings.append(
+                    f"{base_halo_type}: properties are enabled but no variations "
+                    f"are set, so nothing will be computed for {base_halo_type}."
                 )
-        return dict(self.parameters[base_halo_type]["variations"])
+            return {}
+
+        if not has_properties and not self.calculate_missing_properties():
+            self.variation_warnings.append(
+                f"{base_halo_type}: variations are set but no properties are "
+                f"enabled and calculate_missing_properties is False, so nothing "
+                f"will be computed for {base_halo_type}."
+            )
+            section["variations"] = {}
+            return {}
+
+        return dict(section["variations"])
+
+    def print_variation_warnings(self) -> None:
+        """
+        Print any warnings recorded while resolving halo type variations, for
+        example a halo type section that lists properties but no variations.
+        """
+        for warning in self.variation_warnings:
+            print(warning)
 
     def get_particle_property(self, property_name: str) -> Tuple[str, str]:
         """

--- a/SOAP/property_table.py
+++ b/SOAP/property_table.py
@@ -5175,7 +5175,9 @@ Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category & Compression\\\
 
         # Particle limits for each filter
         with open(f"{output_dir}/filters.tex", "w") as ofile:
-            for name, filter_info in self.parameters.parameters["filters"].items():
+            for name, filter_info in self.parameters.parameters.get(
+                "filters", {}
+            ).items():
                 value = filter_info["limit"]
                 ofile.write(f"\\newcommand{{\\{name.lower()}filter}}{{{value}}}\n")
 

--- a/parameter_files/COLIBRE_HYBRID.yml
+++ b/parameter_files/COLIBRE_HYBRID.yml
@@ -761,24 +761,6 @@ filters:
       - BoundSubhalo/NumberOfStarParticles
       - BoundSubhalo/NumberOfBlackHoleParticles
     combine_properties: sum
-  baryon:
-    limit: 0
-    properties:
-      - BoundSubhalo/NumberOfGasParticles
-      - BoundSubhalo/NumberOfStarParticles
-    combine_properties: sum
-  dm:
-    limit: 0
-    properties:
-      - BoundSubhalo/NumberOfDarkMatterParticles
-  gas:
-    limit: 0
-    properties:
-      - BoundSubhalo/NumberOfGasParticles
-  star:
-    limit: 0
-    properties:
-      - BoundSubhalo/NumberOfStarParticles
 defined_constants:
   O_H_sun: 4.9e-4
   Fe_H_sun: 3.16e-5

--- a/parameter_files/COLIBRE_THERMAL.yml
+++ b/parameter_files/COLIBRE_THERMAL.yml
@@ -761,24 +761,6 @@ filters:
       - BoundSubhalo/NumberOfStarParticles
       - BoundSubhalo/NumberOfBlackHoleParticles
     combine_properties: sum
-  baryon:
-    limit: 0
-    properties:
-      - BoundSubhalo/NumberOfGasParticles
-      - BoundSubhalo/NumberOfStarParticles
-    combine_properties: sum
-  dm:
-    limit: 0
-    properties:
-      - BoundSubhalo/NumberOfDarkMatterParticles
-  gas:
-    limit: 0
-    properties:
-      - BoundSubhalo/NumberOfGasParticles
-  star:
-    limit: 0
-    properties:
-      - BoundSubhalo/NumberOfStarParticles
 defined_constants:
   O_H_sun: 4.9e-4
   Fe_H_sun: 3.16e-5

--- a/parameter_files/EAGLE.yml
+++ b/parameter_files/EAGLE.yml
@@ -323,24 +323,6 @@ filters:
       - BoundSubhalo/NumberOfStarParticles
       - BoundSubhalo/NumberOfBlackHoleParticles
     combine_properties: sum
-  baryon:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfGasParticles
-      - BoundSubhalo/NumberOfStarParticles
-    combine_properties: sum
-  dm:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfDarkMatterParticles
-  gas:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfGasParticles
-  star:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfStarParticles
 defined_constants:
   O_H_sun: 4.9e-4
   Fe_H_sun: 3.16e-5

--- a/parameter_files/MINIMAL_FLAMINGO.yml
+++ b/parameter_files/MINIMAL_FLAMINGO.yml
@@ -75,33 +75,6 @@ SubhaloProperties:
     MaximumCircularVelocityRadiusUnsoftened: true
     SpinParameter: true
     TotalMass: true
-filters:
-  general:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfGasParticles
-      - BoundSubhalo/NumberOfDarkMatterParticles
-      - BoundSubhalo/NumberOfStarParticles
-      - BoundSubhalo/NumberOfBlackHoleParticles
-    combine_properties: sum
-  baryon:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfGasParticles
-      - BoundSubhalo/NumberOfStarParticles
-    combine_properties: sum
-  dm:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfDarkMatterParticles
-  gas:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfGasParticles
-  star:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfStarParticles
 calculations:
   calculate_missing_properties: false
   min_read_radius_cmpc: 5

--- a/parameter_files/README.md
+++ b/parameter_files/README.md
@@ -196,6 +196,11 @@ SOAP uses filters to determine whether to skip the calculation of an aperture or
 property based on the number of bound particles. This section of the parameter file
 defines the particle limits for each filter. New filters can be added if required.
 
+There are no default filters. Every filter referenced by a property or a halo type
+variation must be defined here, with the sole exception of the implicit `basic`
+filter (always computed, never listed). SOAP raises an error at startup if a
+property or variation references a filter that is not defined.
+
 ```
 filters:
   general:

--- a/parameter_files/README.md
+++ b/parameter_files/README.md
@@ -113,15 +113,7 @@ ApertureProperties:
       radius_multiple: 2.0
 ```
 
-If you do not wish to calculate any apertures then pass any empty dict to both the properties and the variations, e.g.
-
-```
-ApertureProperties:
-  properties:
-    {}
-  variations:
-    {}
-```
+There are no default variations. If the ApertureProperties section is missing, or no `variations` are listed, then no apertures are computed. If `variations` are listed but no properties are enabled, apertures are still skipped unless `calculate_missing_properties` is true. The same applies to the `ProjectedApertureProperties` and `SOProperties` sections below.
 
 ### ProjectedApertureProperties
 

--- a/tests/small_volume.yml
+++ b/tests/small_volume.yml
@@ -68,33 +68,6 @@ SubhaloProperties:
     MaximumCircularVelocityRadiusUnsoftened: true
     SpinParameter: true
     TotalMass: true
-filters:
-  general:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfGasParticles
-      - BoundSubhalo/NumberOfDarkMatterParticles
-      - BoundSubhalo/NumberOfStarParticles
-      - BoundSubhalo/NumberOfBlackHoleParticles
-    combine_properties: sum
-  baryon:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfGasParticles
-      - BoundSubhalo/NumberOfStarParticles
-    combine_properties: sum
-  dm:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfDarkMatterParticles
-  gas:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfGasParticles
-  star:
-    limit: 100
-    properties:
-      - BoundSubhalo/NumberOfStarParticles
 calculations:
   calculate_missing_properties: false
   min_read_radius_cmpc: 5

--- a/tests/test_SO_properties.py
+++ b/tests/test_SO_properties.py
@@ -39,16 +39,6 @@ def test_SO_properties_random_halo():
     dummy_halos.get_cell_grid().snapshot_datasets.setup_aliases(
         parameters.get_aliases()
     )
-    parameters.get_halo_type_variations(
-        "SOProperties",
-        {
-            "50_kpc": {"value": 50.0, "type": "physical"},
-            "2500_mean": {"value": 2500.0, "type": "mean"},
-            "2500_crit": {"value": 2500.0, "type": "crit"},
-            "BN98": {"value": 0.0, "type": "BN98"},
-            "5xR2500_mean": {"value": 2500.0, "type": "mean", "radius_multiple": 5.0},
-        },
-    )
 
     property_calculator_50kpc = SOProperties(
         dummy_halos.get_cell_grid(),
@@ -397,16 +387,6 @@ def calculate_SO_properties_nfw_halo(seed, num_part, c):
     )
     dummy_halos.get_cell_grid().snapshot_datasets.setup_aliases(
         parameters.get_aliases()
-    )
-    parameters.get_halo_type_variations(
-        "SOProperties",
-        {
-            "50_kpc": {"value": 50.0, "type": "physical"},
-            "2500_mean": {"value": 2500.0, "type": "mean"},
-            "2500_crit": {"value": 2500.0, "type": "crit"},
-            "BN98": {"value": 0.0, "type": "BN98"},
-            "5xR2500_mean": {"value": 2500.0, "type": "mean", "radius_multiple": 5.0},
-        },
     )
 
     property_calculator_200crit = SOProperties(

--- a/tests/test_aperture_properties.py
+++ b/tests/test_aperture_properties.py
@@ -47,13 +47,6 @@ def test_aperture_properties():
     dummy_halos.get_cell_grid().snapshot_datasets.setup_aliases(
         parameters.get_aliases()
     )
-    parameters.get_halo_type_variations(
-        "ApertureProperties",
-        {
-            "exclusive_50_kpc": {"radius_in_kpc": 50.0, "inclusive": False},
-            "inclusive_50_kpc": {"radius_in_kpc": 50.0, "inclusive": True},
-        },
-    )
 
     pc_exclusive = ExclusiveSphereProperties(
         dummy_halos.get_cell_grid(),

--- a/tests/test_parameter_file.py
+++ b/tests/test_parameter_file.py
@@ -6,7 +6,7 @@ from SOAP.core.parameter_file import ParameterFile
 
 
 def make_parameter_file(
-    section=None, calculate_missing_properties=True, snipshot=False
+    section=None, calculate_missing_properties=True, snipshot=False, filters=None
 ):
     """
     Build a ParameterFile with a single ApertureProperties section.
@@ -16,10 +16,29 @@ def make_parameter_file(
     }
     if section is not None:
         parameters["ApertureProperties"] = section
+    if filters is not None:
+        parameters["filters"] = filters
     return ParameterFile(parameter_dictionary=parameters, snipshot=snipshot)
 
 
 VARIATIONS = {"exclusive_50_kpc": {"radius_in_kpc": 50.0, "inclusive": False}}
+
+GENERAL_FILTER = {
+    "general": {
+        "limit": 100,
+        "properties": ["BoundSubhalo/NumberOfDarkMatterParticles"],
+    }
+}
+
+
+def variation_with_filter(filter_name):
+    return {
+        "exclusive_50_kpc": {
+            "radius_in_kpc": 50.0,
+            "inclusive": False,
+            "filter": filter_name,
+        }
+    }
 
 
 def test_missing_section_computes_nothing():
@@ -155,3 +174,68 @@ def test_missing_variations_key_not_reported_as_invalid(capsys):
     assert "ProjectedApertureProperties" not in captured
     assert "NotARealProperty" not in captured
     assert "AlsoNotReal" in captured
+
+
+def test_variation_with_defined_filter_is_accepted():
+    pf = make_parameter_file(
+        section={
+            "properties": {"Mtot": True},
+            "variations": variation_with_filter("general"),
+        },
+        filters=GENERAL_FILTER,
+    )
+    assert list(pf.get_halo_type_variations("ApertureProperties")) == [
+        "exclusive_50_kpc"
+    ]
+
+
+def test_variation_with_basic_filter_is_accepted_without_filters_section():
+    pf = make_parameter_file(
+        section={
+            "properties": {"Mtot": True},
+            "variations": variation_with_filter("basic"),
+        },
+    )
+    assert list(pf.get_halo_type_variations("ApertureProperties")) == [
+        "exclusive_50_kpc"
+    ]
+
+
+def test_variation_without_filter_key_is_accepted_without_filters_section():
+    pf = make_parameter_file(
+        section={"properties": {"Mtot": True}, "variations": VARIATIONS},
+    )
+    assert list(pf.get_halo_type_variations("ApertureProperties")) == [
+        "exclusive_50_kpc"
+    ]
+
+
+def test_variation_with_undefined_filter_raises():
+    pf = make_parameter_file(
+        section={
+            "properties": {"Mtot": True},
+            "variations": variation_with_filter("not_a_filter"),
+        },
+    )
+    with pytest.raises(ValueError, match="not_a_filter"):
+        pf.get_halo_type_variations("ApertureProperties")
+
+
+def test_property_with_defined_filter_is_accepted():
+    pf = make_parameter_file(
+        section={"properties": {"Mtot": "general"}}, filters=GENERAL_FILTER
+    )
+    filters = pf.get_property_filters("ApertureProperties", ["Mtot"])
+    assert filters["Mtot"] == "general"
+
+
+def test_property_true_resolves_to_basic_without_filters_section():
+    pf = make_parameter_file(section={"properties": {"Mtot": True}})
+    filters = pf.get_property_filters("ApertureProperties", ["Mtot"])
+    assert filters["Mtot"] == "basic"
+
+
+def test_property_with_undefined_filter_raises():
+    pf = make_parameter_file(section={"properties": {"Mtot": "not_a_filter"}})
+    with pytest.raises(ValueError, match="not_a_filter"):
+        pf.get_property_filters("ApertureProperties", ["Mtot"])

--- a/tests/test_parameter_file.py
+++ b/tests/test_parameter_file.py
@@ -1,0 +1,157 @@
+#!/bin/env python
+
+import pytest
+
+from SOAP.core.parameter_file import ParameterFile
+
+
+def make_parameter_file(
+    section=None, calculate_missing_properties=True, snipshot=False
+):
+    """
+    Build a ParameterFile with a single ApertureProperties section.
+    """
+    parameters = {
+        "calculations": {"calculate_missing_properties": calculate_missing_properties},
+    }
+    if section is not None:
+        parameters["ApertureProperties"] = section
+    return ParameterFile(parameter_dictionary=parameters, snipshot=snipshot)
+
+
+VARIATIONS = {"exclusive_50_kpc": {"radius_in_kpc": 50.0, "inclusive": False}}
+
+
+def test_missing_section_computes_nothing():
+    pf = make_parameter_file(section=None)
+    assert pf.get_halo_type_variations("ApertureProperties") == {}
+    assert pf.variation_warnings == []
+
+
+@pytest.mark.parametrize(
+    "section",
+    [
+        {"properties": {}, "variations": {}},
+        {"properties": {"Mtot": False}, "variations": {}},
+        {},
+    ],
+)
+def test_no_variations_no_properties_is_silent(section):
+    pf = make_parameter_file(section=section)
+    assert pf.get_halo_type_variations("ApertureProperties") == {}
+    assert pf.variation_warnings == []
+
+
+@pytest.mark.parametrize(
+    "section",
+    [
+        {"properties": {"Mtot": True}, "variations": {}},
+        {"properties": {"Mtot": "general"}},
+        {"properties": {"Mtot": {"snapshot": True, "snipshot": False}}},
+    ],
+)
+def test_properties_but_no_variations_warns_and_skips(section):
+    pf = make_parameter_file(section=section)
+    assert pf.get_halo_type_variations("ApertureProperties") == {}
+    assert len(pf.variation_warnings) == 1
+    assert "no variations" in pf.variation_warnings[0]
+
+
+def test_variations_no_properties_with_calculate_missing():
+    pf = make_parameter_file(
+        section={"properties": {}, "variations": VARIATIONS},
+        calculate_missing_properties=True,
+    )
+    assert list(pf.get_halo_type_variations("ApertureProperties")) == [
+        "exclusive_50_kpc"
+    ]
+    assert pf.variation_warnings == []
+
+
+@pytest.mark.parametrize(
+    "properties",
+    [{}, {"Mtot": False}, {"Mtot": {"snapshot": False, "snipshot": False}}],
+)
+def test_variations_no_properties_without_calculate_missing_warns_and_skips(properties):
+    pf = make_parameter_file(
+        section={"properties": properties, "variations": VARIATIONS},
+        calculate_missing_properties=False,
+    )
+    assert pf.get_halo_type_variations("ApertureProperties") == {}
+    assert len(pf.variation_warnings) == 1
+    assert "calculate_missing_properties is False" in pf.variation_warnings[0]
+    # The skipped variations should also be cleared from the stored parameters
+    assert pf.parameters["ApertureProperties"]["variations"] == {}
+
+
+def test_variations_and_properties_is_the_normal_case():
+    pf = make_parameter_file(
+        section={"properties": {"Mtot": True}, "variations": VARIATIONS},
+        calculate_missing_properties=False,
+    )
+    assert list(pf.get_halo_type_variations("ApertureProperties")) == [
+        "exclusive_50_kpc"
+    ]
+    assert pf.variation_warnings == []
+
+
+def test_snipshot_mode_used_when_deciding_if_properties_enabled():
+    # Property is enabled for snapshots only, but we are running a snipshot
+    pf = make_parameter_file(
+        section={
+            "properties": {"Mtot": {"snapshot": True, "snipshot": False}},
+            "variations": VARIATIONS,
+        },
+        calculate_missing_properties=False,
+        snipshot=True,
+    )
+    assert pf.get_halo_type_variations("ApertureProperties") == {}
+    assert len(pf.variation_warnings) == 1
+
+
+def test_empty_variations_section_not_reported_as_invalid(capsys):
+    pf = ParameterFile(
+        parameter_dictionary={
+            "ProjectedApertureProperties": {
+                "properties": {"GasMass": True, "NotARealProperty": True},
+                "variations": {},
+            },
+            "SubhaloProperties": {"properties": {"AlsoNotReal": True}},
+            "calculations": {"calculate_missing_properties": True},
+        }
+    )
+    pf.get_halo_type_variations("ProjectedApertureProperties")
+
+    # halo_prop_list is empty since the section has no variations
+    pf.print_invalid_properties([])
+    captured = capsys.readouterr().out
+
+    # Properties under the empty-variations section are unused, not invalid
+    assert "ProjectedApertureProperties" not in captured
+    assert "NotARealProperty" not in captured
+    # Sections without a variations key at all are still validated
+    assert "AlsoNotReal" in captured
+
+
+def test_missing_variations_key_not_reported_as_invalid(capsys):
+    # As above, but the section has no 'variations' key at all;
+    # get_halo_type_variations should insert an empty one so that
+    # print_invalid_properties skips the section
+    pf = ParameterFile(
+        parameter_dictionary={
+            "ProjectedApertureProperties": {
+                "properties": {"GasMass": True, "NotARealProperty": True},
+            },
+            "SubhaloProperties": {"properties": {"AlsoNotReal": True}},
+            "calculations": {"calculate_missing_properties": True},
+        }
+    )
+    pf.get_halo_type_variations("ProjectedApertureProperties")
+    assert pf.parameters["ProjectedApertureProperties"]["variations"] == {}
+
+    pf.print_invalid_properties([])
+    captured = capsys.readouterr().out
+
+    assert "ProjectedApertureProperties" not in captured
+    assert "NotARealProperty" not in captured
+    assert "AlsoNotReal" in captured

--- a/tests/test_parameter_file.py
+++ b/tests/test_parameter_file.py
@@ -1,8 +1,18 @@
 #!/bin/env python
 
+import glob
+import os
+
 import pytest
 
 from SOAP.core.parameter_file import ParameterFile
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Every parameter file shipped in the repo, plus the full test config
+SHIPPED_PARAMETER_FILES = sorted(
+    glob.glob(os.path.join(REPO_ROOT, "parameter_files", "*.yml"))
+) + [os.path.join(REPO_ROOT, "tests", "small_volume.yml")]
 
 
 def make_parameter_file(
@@ -239,3 +249,77 @@ def test_property_with_undefined_filter_raises():
     pf = make_parameter_file(section={"properties": {"Mtot": "not_a_filter"}})
     with pytest.raises(ValueError, match="not_a_filter"):
         pf.get_property_filters("ApertureProperties", ["Mtot"])
+
+
+# ---------------------------------------------------------------------------
+# check_schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", SHIPPED_PARAMETER_FILES)
+@pytest.mark.parametrize("snipshot", [False, True])
+def test_shipped_parameter_files_pass_schema(path, snipshot):
+    ParameterFile(file_name=path, snipshot=snipshot).check_schema()
+
+
+def valid_schema_dict():
+    return {
+        "HaloFinder": {"type": "HBTplus", "filename": "hbt"},
+        "SubhaloProperties": {"properties": {"TotalMass": True}},
+        "ApertureProperties": {"properties": {}, "variations": {}},
+        "calculations": {"calculate_missing_properties": True},
+    }
+
+
+def check_schema_of(params):
+    ParameterFile(parameter_dictionary=params).check_schema()
+
+
+def test_valid_schema_dict_passes():
+    check_schema_of(valid_schema_dict())
+
+
+def test_unknown_top_level_section_is_reported():
+    params = valid_schema_dict()
+    params["ApatureProperties"] = {}
+    with pytest.raises(ValueError, match="ApatureProperties"):
+        check_schema_of(params)
+
+
+def test_unknown_key_in_halo_type_section_is_reported():
+    params = valid_schema_dict()
+    params["ApertureProperties"]["variation"] = {}
+    with pytest.raises(ValueError, match=r'unknown key "ApertureProperties/variation"'):
+        check_schema_of(params)
+
+
+def test_unknown_key_in_halo_finder_is_reported():
+    params = valid_schema_dict()
+    params["HaloFinder"]["filenme"] = "typo"
+    with pytest.raises(ValueError, match=r'unknown key "HaloFinder/filenme"'):
+        check_schema_of(params)
+
+
+def test_unknown_calculations_key_is_reported():
+    params = valid_schema_dict()
+    params["calculations"]["calculate_missing_property"] = True
+    with pytest.raises(ValueError, match="calculate_missing_property"):
+        check_schema_of(params)
+
+
+def test_free_form_sections_are_not_checked():
+    params = valid_schema_dict()
+    params["filters"] = {"my_filter": {"limit": 100}}
+    params["aliases"] = {"PartType0/Foo": "PartType0/Bar"}
+    check_schema_of(params)
+
+
+def test_check_schema_reports_all_errors_together():
+    params = valid_schema_dict()
+    params["Nonsense"] = {}
+    params["HaloFinder"]["oops"] = 1
+    with pytest.raises(ValueError) as excinfo:
+        check_schema_of(params)
+    message = str(excinfo.value)
+    assert "Nonsense" in message
+    assert "oops" in message

--- a/tests/test_projected_aperture_properties.py
+++ b/tests/test_projected_aperture_properties.py
@@ -37,9 +37,6 @@ def test_projected_aperture_properties():
     dummy_halos.get_cell_grid().snapshot_datasets.setup_aliases(
         parameters.get_aliases()
     )
-    parameters.get_halo_type_variations(
-        "ProjectedApertureProperties", {"30_kpc": {"radius_in_kpc": 30.0}}
-    )
 
     pc_projected = ProjectedApertureProperties(
         dummy_halos.get_cell_grid(),

--- a/tests/test_subhalo_properties.py
+++ b/tests/test_subhalo_properties.py
@@ -37,10 +37,6 @@ def test_subhalo_properties():
     dummy_halos.get_cell_grid().snapshot_datasets.setup_aliases(
         parameters.get_aliases()
     )
-    parameters.get_halo_type_variations(
-        "SubhaloProperties",
-        {},
-    )
 
     recently_heated_gas_filter = dummy_halos.get_recently_heated_gas_filter()
     stellar_age_calculator = StellarAgeCalculator(dummy_halos.get_cell_grid())


### PR DESCRIPTION
  - **Handle missing sections** Removed the hard-coded default aperture and SO variations, so a
    halo-type section that is missing or lists no variations now computes nothing instead of
    silently falling back to defaults and crashing. Closes https://github.com/SWIFTSIM/SOAP/issues/214
  - **Remove default filters** Removed the hard-coded default category filters (`general`, `dm`, `gas`,
    `star`, `baryon`); every filter referenced by a property or a variation must now be defined
    in the filters section, and unused definitions have been stripped from the parameter
    files. Filter names used in variations are now validated, so a typo aborts at startup with
    a clear message instead of a `KeyError` partway through a run.
  - **Add checking of top-level keys** Added a `check_schema()` pass that runs at startup and
    aborts if the parameter file has an unrecognised section, or a mistyped key directly under
    one of the sections that has a fixed set of keys. This catches typos such as `variation:`
    instead `of variations:` that would otherwise be silently ignored.
